### PR TITLE
Generate stable ID for RSS 1.0 items

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -26,5 +26,6 @@ lazy_static = "1.4"
 mime = "0.3"
 regex = "1.3"
 serde = { version = "1.0", optional = true, features = ["derive"] }
+siphasher = "0.3"
 uuid = { version = "0.8", features = ["v4"] }
 xml-rs = "0.8"

--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -213,6 +213,7 @@ pub struct Entry {
     /// A unique identifier for this item with a feed. If not supplied it is initialised to a UUID.
     /// * Atom (required): Identifies the entry using a universally unique and permanent URI.
     /// * RSS 2 (optional) "guid": A string that uniquely identifies the item.
+    /// * RSS 1: does not specify a unique ID as a separate item, but does suggest the URI should be "the same as the link" so we use a hash of the link if found
     pub id: String,
     /// Title of this item within the feed
     /// * Atom, RSS 1(required): Contains a human readable title for the entry.

--- a/feed-rs/src/parser/rss1/mod.rs
+++ b/feed-rs/src/parser/rss1/mod.rs
@@ -1,4 +1,7 @@
+use std::hash::Hasher;
 use std::io::Read;
+
+use siphasher::sip128::{SipHasher, Hasher128};
 
 use crate::model::{Entry, Feed, Image, Link, Text};
 use crate::parser::ParseFeedResult;
@@ -67,6 +70,9 @@ fn handle_image<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Image>> 
     })
 }
 
+const LINK_HASH_KEY1: u64 = 0x5d78407428872d60;
+const LINK_HASH_KEY2: u64 = 0x90eeca4c90a5e228;
+
 // Handles <item>
 fn handle_item<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Entry>> {
     let mut entry = Entry::default();
@@ -83,10 +89,18 @@ fn handle_item<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Entry>> {
         }
     }
 
-    // No point returning anything if we are missing a destination
+    // If we found at least 1 link
     Ok(if !entry.links.is_empty() {
+        // Generate a stable ID for this item based on the first link
+        let link = entry.links.iter().next().unwrap();
+        let mut hasher = SipHasher::new_with_keys(LINK_HASH_KEY1, LINK_HASH_KEY2);
+        hasher.write(link.href.as_bytes());
+        let hash = hasher.finish128();
+        entry.id = format!("{:x}{:x}", hash.h1, hash.h2);
+
         Some(entry)
     } else {
+        // No point returning anything if we are missing a destination
         None
     })
 }

--- a/feed-rs/src/parser/rss1/tests.rs
+++ b/feed-rs/src/parser/rss1/tests.rs
@@ -20,14 +20,14 @@ fn test_example_1() {
         .description(Text::new("Site description".to_owned()))
         .updated(actual.updated)    // not present in the test data
         .entry(Entry::default()
-            .id(entry0.id.as_ref())             // not present in the test data
-            .updated(entry0.updated)            // not present in the test data
+            .id("e759cc25dc488d95ec723f6553e10a4e")     // hash of the link
+            .updated(entry0.updated)                    // not present in the test data
             .title(Text::new("記事1のタイトル".to_owned()))
             .link(Link::new("記事1のURL".to_owned()))
             .summary(Text::new("記事1の内容".to_owned())))
         .entry(Entry::default()
-            .id(entry1.id.as_ref())             // not present in the test data
-            .updated(entry1.updated)            // not present in the test data
+            .id("2c802e03278c5c9b7c6f3690f69f7570")     // hash of the link
+            .updated(entry1.updated)                    // not present in the test data
             .title(Text::new("記事2のタイトル".to_owned()))
             .link(Link::new("記事2のURL".to_owned()))
             .summary(Text::new("記事2の内容".to_owned())));
@@ -56,13 +56,13 @@ fn test_spec_1() {
             .title("XML.com"))
         .updated(actual.updated)    // not present in the test data
         .entry(Entry::default()
-            .id(entry0.id.as_ref())             // not present in the test data
+            .id("4e02e6b5e0c197983a5347308272fa20")     // hash of the link
             .updated(entry0.updated)            // not present in the test data
             .title(Text::new("Processing Inclusions with XSLT".to_owned()))
             .link(Link::new("http://xml.com/pub/2000/08/09/xslt/xslt.html".to_owned()))
             .summary(Text::new("Processing document inclusions with general XML tools can be\n            problematic. This article proposes a way of preserving inclusion\n            information through SAX-based processing.".to_owned())))
         .entry(Entry::default()
-            .id(entry1.id.as_ref())             // not present in the test data
+            .id("82feaa3d819de1de3e5ed0eb59b53706")     // hash of the link
             .updated(entry1.updated)            // not present in the test data
             .title(Text::new("Putting RDF to Work".to_owned()))
             .link(Link::new("http://xml.com/pub/2000/08/09/rdfdb/index.html".to_owned()))
@@ -91,7 +91,7 @@ fn test_spec_2() {
             .title("Meerkat Powered!"))
         .updated(actual.updated)    // not present in the test data
         .entry(Entry::default()
-            .id(entry0.id.as_ref())             // not present in the test data
+            .id("3c8aa6d4cb85520f531b5a9c08498d04")     // hash of the link
             .updated(entry0.updated)            // not present in the test data
             .title(Text::new("XML: A Disruptive Technology".to_owned()))
             .link(Link::new("http://c.moreover.com/click/here.pl?r123".to_owned()))


### PR DESCRIPTION
RSS 1.0 does not define a unique ID for an item within a feed, but does
indicate that the URI should be the same as the link.

We now use the first link to generate a hash and use that as a stable
ID.

Close #11 