### PR TITLE
Publish 0.2.1

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feed-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = '2018'
 authors = ["Hiroki Kumamoto <kumabook@live.jp>", "Mark Pritchard <mpritcha@gmail.com>"]
 include = [


### PR DESCRIPTION
- support for JSON Feed
- various fixes for RSS 2 (mostly handling invalid dates)
- assign a stable ID for RSS 1 (based on link URI)