### PR TITLE
Use hash for Feed and Entry IDs

### DIFF
--- a/feed-rs/fixture/rss_2.0_example_6.xml
+++ b/feed-rs/fixture/rss_2.0_example_6.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
+    <channel>
+        <title>Latest Movie Trailers</title>
+        <link>https://trailers.apple.com/</link>
+        <description>Recently added Movie Trailers.</description>
+        <language>en-US</language>
+        <lastBuildDate>Fri, 07 Feb 2020 07:30:28 PST</lastBuildDate>
+        <generator>Custom</generator>
+        <copyright>2020 Apple Inc.</copyright>
+        <item>
+            <title>Vitalina Varela - Trailer</title>
+            <link>https://trailers.apple.com/trailers/independent/vitalina-varela</link>
+            <description>A film of deeply concentrated beauty, acclaimed filmmaker Pedro Costa’s VITALINA VARELA stars nonprofessional actor Vitalina Varela in an extraordinary performance based on her own life. Vitalina plays a Cape Verdean woman who has travelled to Lisbon to reunite with her husband, after two decades of separation, only to arrive mere days after his funeral. Alone in a strange forbidding land, she perseveres and begins to establish a new life. Winner of the Golden Leopard for Best Film and Best Actress at the Locarno Film Festival, as well as an official selection of the Sundance Film Festival, VITALINA VARELA is a film of shadow and whisper, a profoundly moving and visually ravishing masterpiece.</description>
+            <pubDate>Thu, 06 Feb 2020 00:00:00 PST</pubDate>
+            <content:encoded><![CDATA[
+			<table>
+			<tr valign="top">
+			<td width="67"><a href="https://trailers.apple.com/trailers/independent/vitalina-varela"><img src="https://trailers.apple.com/trailers/independent/vitalina-varela/images/poster.jpg" width="65" height="97" border="0"></a></td>
+			<td> &nbsp; </td>
+			<td><a href="https://trailers.apple.com/trailers/independent/vitalina-varela"><span style="font-size: 16px; font-weight: 900; text-decoration: underline;">Vitalina Varela - Trailer</span></a><br />
+			<span style="font-size: 12px;">A film of deeply concentrated beauty, acclaimed filmmaker Pedro Costa’s VITALINA VARELA stars nonprofessional actor Vitalina Varela in an extraordinary performance based on her own life. Vitalina plays a Cape Verdean woman who has travelled to Lisbon to reunite with her husband, after two decades of separation, only to arrive mere days after his funeral. Alone in a strange forbidding land, she perseveres and begins to establish a new life. Winner of the Golden Leopard for Best Film and Best Actress at the Locarno Film Festival, as well as an official selection of the Sundance Film Festival, VITALINA VARELA is a film of shadow and whisper, a profoundly moving and visually ravishing masterpiece.<br /><b>Directed by:</b> Pedro Costa<br /><b>Starring:</b> Vitalina Varela, Ventura, Manuel Tavares Almeida, Francisco Brito</span></td>
+			</tr>
+			</table>
+			]]></content:encoded>
+        </item>
+    </channel>
+</rss>

--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -1,7 +1,6 @@
 use chrono::{DateTime, Utc};
 use mime::Mime;
 
-use crate::util;
 #[cfg(test)]
 use crate::parser::util::timestamp_rfc2822_lenient;
 #[cfg(test)]
@@ -32,7 +31,7 @@ use crate::parser::util::timestamp_rfc3339;
 pub struct Feed {
     /// A unique identifier for this feed
     /// * Atom (required): Identifies the feed using a universally unique and permanent URI.
-    /// * RSS doesn't require an ID so it is initialised to a UUID
+    /// * RSS doesn't require an ID so it is initialised to the hash of the first link or a UUID if not found
     pub id: String,
     /// The title of the feed
     /// * Atom (required): Contains a human readable title for the feed. Often the same as the title of the associated website. This value should not be blank.
@@ -100,7 +99,7 @@ pub struct Feed {
 impl Default for Feed {
     fn default() -> Self {
         Feed {
-            id: util::uuid_gen(),
+            id: "".into(),
             title: None,
             updated: Utc::now(),
             authors: Vec::new(),
@@ -217,7 +216,7 @@ impl Feed {
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Entry {
-    /// A unique identifier for this item with a feed. If not supplied it is initialised to a UUID.
+    /// A unique identifier for this item with a feed. If not supplied it is initialised to a hash of the first link or a UUID if not available.
     /// * Atom (required): Identifies the entry using a universally unique and permanent URI.
     /// * RSS 2 (optional) "guid": A string that uniquely identifies the item.
     /// * RSS 1: does not specify a unique ID as a separate item, but does suggest the URI should be "the same as the link" so we use a hash of the link if found
@@ -276,10 +275,8 @@ pub struct Entry {
 
 impl Default for Entry {
     fn default() -> Self {
-        let id = util::uuid_gen();
-
         Entry {
-            id,
+            id: "".into(),
             title: None,
             updated: Utc::now(),
             authors: Vec::new(),

--- a/feed-rs/src/parser/json/mod.rs
+++ b/feed-rs/src/parser/json/mod.rs
@@ -78,7 +78,7 @@ fn handle_item(ji: JsonItem) -> ParseFeedResult<Entry> {
 
     // Content HTML, content text and summary are mapped across to our model with the preference toward HTML and explicit summary fields
     entry.content = handle_content(ji.content_html, mime::TEXT_HTML);
-    entry.summary = ji.summary.map(|s| Text::new(s));
+    entry.summary = ji.summary.map(Text::new);
     if let Some(content_text) = handle_content(ji.content_text, mime::TEXT_PLAIN) {
         // If we don't have HTML content, use the text content as the entry content
         // otherwise, if the summary was not provided, we push the text there
@@ -86,7 +86,7 @@ fn handle_item(ji: JsonItem) -> ParseFeedResult<Entry> {
         if entry.content.is_none() {
             entry.content = Some(content_text);
         } else if entry.summary.is_none() {
-            entry.summary = content_text.body.map(|t| Text::new(t));
+            entry.summary = content_text.body.map(Text::new);
         }
     }
 
@@ -101,13 +101,13 @@ fn handle_item(ji: JsonItem) -> ParseFeedResult<Entry> {
 
     if let Some(tags) = ji.tags {
         tags.into_iter()
-            .map(|tag| Category::new(tag))
+            .map(Category::new)
             .for_each(|category| entry.categories.push(category));
     }
 
     if let Some(attachments) = ji.attachments {
         attachments.into_iter()
-            .map(|attachment| handle_attachment(attachment))
+            .map(handle_attachment)
             .for_each(|link| entry.links.push(link))
     }
 
@@ -126,7 +126,7 @@ fn handle_person(author: Option<JsonAuthor>) -> Option<Person> {
         }
     }
 
-    return None;
+    None
 }
 
 #[derive(Debug, Deserialize)]

--- a/feed-rs/src/parser/mod.rs
+++ b/feed-rs/src/parser/mod.rs
@@ -121,11 +121,11 @@ fn assign_missing_ids(feed: &mut model::Feed) {
     }
 }
 
-const LINK_HASH_KEY1: u64 = 0x5d78407428872d60;
-const LINK_HASH_KEY2: u64 = 0x90eeca4c90a5e228;
+const LINK_HASH_KEY1: u64 = 0x5d78_4074_2887_2d60;
+const LINK_HASH_KEY2: u64 = 0x90ee_ca4c_90a5_e228;
 
 // Creates a unique ID from the first link, or a UUID if no links are available
-fn create_id(links : &Vec<model::Link>) -> String {
+fn create_id(links : &[model::Link]) -> String {
     // Generate a stable ID for this item based on the first link
     if let Some(link) = links.iter().next() {
         let mut hasher = SipHasher::new_with_keys(LINK_HASH_KEY1, LINK_HASH_KEY2);

--- a/feed-rs/src/parser/rss1/mod.rs
+++ b/feed-rs/src/parser/rss1/mod.rs
@@ -1,7 +1,4 @@
-use std::hash::Hasher;
 use std::io::Read;
-
-use siphasher::sip128::{SipHasher, Hasher128};
 
 use crate::model::{Entry, Feed, Image, Link, Text};
 use crate::parser::ParseFeedResult;
@@ -70,9 +67,6 @@ fn handle_image<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Image>> 
     })
 }
 
-const LINK_HASH_KEY1: u64 = 0x5d78407428872d60;
-const LINK_HASH_KEY2: u64 = 0x90eeca4c90a5e228;
-
 // Handles <item>
 fn handle_item<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Entry>> {
     let mut entry = Entry::default();
@@ -91,13 +85,6 @@ fn handle_item<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Entry>> {
 
     // If we found at least 1 link
     Ok(if !entry.links.is_empty() {
-        // Generate a stable ID for this item based on the first link
-        let link = entry.links.iter().next().unwrap();
-        let mut hasher = SipHasher::new_with_keys(LINK_HASH_KEY1, LINK_HASH_KEY2);
-        hasher.write(link.href.as_bytes());
-        let hash = hasher.finish128();
-        entry.id = format!("{:x}{:x}", hash.h1, hash.h2);
-
         Some(entry)
     } else {
         // No point returning anything if we are missing a destination

--- a/feed-rs/src/parser/rss2/mod.rs
+++ b/feed-rs/src/parser/rss2/mod.rs
@@ -176,7 +176,7 @@ fn handle_link<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Link>> {
     Ok(element.child_as_text()?.map(Link::new))
 }
 
-// Handles <title>, <description>
+// Handles <title>, <description>, <encoded>
 fn handle_text<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Text>> {
     Ok(element.child_as_text()?.map(Text::new))
 }

--- a/feed-rs/src/parser/rss2/tests.rs
+++ b/feed-rs/src/parser/rss2/tests.rs
@@ -165,6 +165,35 @@ fn test_example_5() {
     assert_eq!(actual, expected);
 }
 
+// Trailers from Apple (no UUID)
+#[test]
+fn test_example_6() {
+    // Parse the feed
+    let test_data = test::fixture_as_string("rss_2.0_example_6.xml");
+    let actual = parser::parse(test_data.as_bytes()).unwrap();
+
+    // Expected feed
+    let expected = Feed::default()
+        .id("8aed7f5d4466ac2c2de684823e36f0b4")     // hash of the link
+        .title(Text::new("Latest Movie Trailers".into()))
+        .link(Link::new("https://trailers.apple.com/".into()))
+        .description(Text::new("Recently added Movie Trailers.".into()))
+        .language("en-us")
+        .updated_rfc3339("2020-02-07T15:30:28Z")
+        .generator(Generator::new("Custom".into()))
+        .rights(Text::new("2020 Apple Inc.".into()))
+        .entry(Entry::default()
+            .title(Text::new("Vitalina Varela - Trailer".into()))
+            .link(Link::new("https://trailers.apple.com/trailers/independent/vitalina-varela".into()))
+            .summary(Text::new("A film of deeply concentrated beauty, acclaimed filmmaker Pedro Costa’s VITALINA VARELA stars nonprofessional actor Vitalina Varela in an extraordinary performance based on her own life. Vitalina plays a Cape Verdean woman who has travelled to Lisbon to reunite with her husband, after two decades of separation, only to arrive mere days after his funeral. Alone in a strange forbidding land, she perseveres and begins to establish a new life. Winner of the Golden Leopard for Best Film and Best Actress at the Locarno Film Festival, as well as an official selection of the Sundance Film Festival, VITALINA VARELA is a film of shadow and whisper, a profoundly moving and visually ravishing masterpiece.".into()))
+            .published_rfc3339("2020-02-06T08:00:00Z")
+            .id("93c9e7fec11765c4547e537067e0155d")        // hash of the link
+            .updated(actual.updated));
+
+    // Check
+    assert_eq!(actual, expected);
+}
+
 // Verify we can parse the example contained in the RSS 2.0 specification
 #[test]
 fn test_spec_1() {

--- a/feed-rs/src/parser/util.rs
+++ b/feed-rs/src/parser/util.rs
@@ -1,6 +1,7 @@
 use crate::parser::{ParseFeedResult, ParseFeedError, ParseErrorKind};
 use chrono::{DateTime, Utc};
 use regex::Regex;
+use uuid::Uuid;
 
 lazy_static! {
     // Initialise the set of regular expressions we use to clean up broken dates
@@ -58,6 +59,11 @@ pub fn timestamp_rfc3339(text: &str) -> ParseFeedResult<DateTime<Utc>> {
     DateTime::parse_from_rfc3339(text.trim())
         .map(|t| t.with_timezone(&Utc))
         .map_err(|pe| ParseFeedError::ParseError(ParseErrorKind::InvalidDateTime(Box::new(pe))))
+}
+
+/// Generates a new UUID.
+pub fn uuid_gen() -> String {
+    Uuid::new_v4().to_string()
 }
 
 #[cfg(test)]

--- a/feed-rs/src/parser/util.rs
+++ b/feed-rs/src/parser/util.rs
@@ -21,6 +21,7 @@ lazy_static! {
             (Regex::new("(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*").unwrap(), "$1"),
 
             // Some timestamps have an hours component adjusted by 24h, while not adjusting the day so we just reset to start of day
+            #[allow(clippy::trivial_regex)]
             (Regex::new(" 24:").unwrap(), " 00:"),
 
             // Single digit hours are padded

--- a/feed-rs/src/util/mod.rs
+++ b/feed-rs/src/util/mod.rs
@@ -1,4 +1,3 @@
-use uuid::Uuid;
 use xml::attribute::OwnedAttribute;
 
 pub mod element_source;
@@ -8,11 +7,6 @@ pub fn attr_value<'a>(attributes: &'a [OwnedAttribute], name: &str) -> Option<&'
     attributes.iter()
         .find(|attr| attr.name.local_name == name)
         .map(|attr| attr.value.as_str())
-}
-
-/// Generates a new UUID.
-pub fn uuid_gen() -> String {
-    Uuid::new_v4().to_string()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
RSS feeds do not consistently provide an ID, so we now generate one from
the first link or assign a UUID if there are no links present.

Closes #18, closes #19