### PR TITLE
Publish 0.2.2

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feed-rs"
-version = "0.2.1"
+version = "0.2.2"
 edition = '2018'
 authors = ["Hiroki Kumamoto <kumabook@live.jp>", "Mark Pritchard <mpritcha@gmail.com>"]
 include = [


### PR DESCRIPTION
- optional feed and entry timestamps
- stable IDs for feeds and entries

[ci skip]