### PR TITLE
fix: remove unwrap from ElementIter

### DIFF
--- a/feed-rs/src/parser/atom/mod.rs
+++ b/feed-rs/src/parser/atom/mod.rs
@@ -15,6 +15,7 @@ mod tests;
 pub fn parse<R: Read>(root: Element<R>) -> ParseFeedResult<Feed> {
     let mut feed = Feed::default();
     for child in root.children() {
+        let child = child?;
         let tag_name = child.name.local_name.as_str();
         match tag_name {
             "id" => if let Some(id) = child.child_as_text()? { feed.id = id },
@@ -125,6 +126,7 @@ fn handle_entry<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Entry>> 
     let mut entry = Entry::default();
 
     for child in element.children() {
+        let child = child?;
         let tag_name = child.name.local_name.as_str();
         match tag_name {
             // Extract the fields from the spec
@@ -209,6 +211,7 @@ fn handle_person<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Person>
     let mut person = Person::new(String::from("unknown"));
 
     for child in element.children() {
+        let child = child?;
         let tag_name = child.name.local_name.as_str();
         let child_text = child.child_as_text()?;
         match (tag_name, child_text) {

--- a/feed-rs/src/parser/rss1/mod.rs
+++ b/feed-rs/src/parser/rss1/mod.rs
@@ -12,6 +12,7 @@ pub fn parse<R: Read>(root: Element<R>) -> ParseFeedResult<Feed> {
     let mut feed = Feed::default();
 
     for child in root.children() {
+        let child = child?;
         let tag_name = child.name.local_name.as_str();
         match tag_name {
             "channel" => handle_channel(&mut feed, child)?,
@@ -29,6 +30,7 @@ pub fn parse<R: Read>(root: Element<R>) -> ParseFeedResult<Feed> {
 // Handles the <channel> element
 fn handle_channel<R: Read>(feed: &mut Feed, channel: Element<R>) -> ParseFeedResult<()> {
     for child in channel.children() {
+        let child = child?;
         let tag_name = child.name.local_name.as_str();
         match tag_name {
             "title" => feed.title = handle_text(child)?,
@@ -48,6 +50,7 @@ fn handle_image<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Image>> 
     let mut image = Image::new("".to_owned());
 
     for child in element.children() {
+        let child = child?;
         let tag_name = child.name.local_name.as_str();
         match tag_name {
             "url" => if let Some(url) = child.child_as_text()? { image.uri = url },
@@ -72,6 +75,7 @@ fn handle_item<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Entry>> {
     let mut entry = Entry::default();
 
     for child in element.children() {
+        let child = child?;
         let tag_name = child.name.local_name.as_str();
         match tag_name {
             "title" => entry.title = handle_text(child)?,

--- a/feed-rs/src/util/element_source.rs
+++ b/feed-rs/src/util/element_source.rs
@@ -244,10 +244,10 @@ pub struct ElementIter<'a, R: Read> {
 }
 
 impl<'a, R: Read> Iterator for ElementIter<'a, R> {
-    type Item = Element<'a, R>;
+    type Item = Result<Element<'a, R>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.source.next_element_at_depth(self.depth).unwrap()
+        self.source.next_element_at_depth(self.depth).transpose()
     }
 }
 
@@ -290,6 +290,7 @@ mod tests {
         // Iterate over the children of the book
         let mut count = 0;
         for child in book.children() {
+            let child = child?;
             match child.name.local_name.as_str() {
                 "author" => {
                     count += 1;
@@ -319,6 +320,7 @@ mod tests {
         // Iterate over the children of the catalog
         let mut count = 0;
         for child in catalog.children() {
+            let child = child?;
             // First child should be book
             assert_eq!(child.name.local_name, "book");
 
@@ -340,6 +342,7 @@ mod tests {
         // Should have a single child called "nest2"
         let mut count = 0;
         for child in nest1.children() {
+            let child = child?;
             // First child should be nest2
             assert_eq!(child.name.local_name, "nest2");
 
@@ -378,7 +381,7 @@ mod tests {
         assert_eq!(catalog.name.local_name, "catalog");
 
         // Next element should be "book"
-        let book: Element<_> = catalog.children().next().unwrap();
+        let book: Element<_> = catalog.children().next().unwrap()?;
         assert_eq!(book.name.local_name, "book");
 
         // Contents should be as we expect


### PR DESCRIPTION
Changes `ElementIter` to return a `Result<Element>` so that we it can propagate xml errors correctly. The previous implementation used an unwrap that would panic if the XML was invalid while iterating over children elements.

I tried to apply the smallest change on every call site possible, but suggestions are welcome. Running it over my list of RSS urls produced no more panics.

Closes #26 