### PR TITLE
Lower Rust requirement

### DIFF
--- a/feed-rs/src/parser/util.rs
+++ b/feed-rs/src/parser/util.rs
@@ -44,14 +44,14 @@ pub fn timestamp_rfc2822_lenient(text: &str) -> Option<DateTime<Utc>> {
     }
 
     DateTime::parse_from_rfc2822(&text)
-        .map_or(None, |t| Some(t.with_timezone(&Utc)))
+        .map(|t| t.with_timezone(&Utc)).ok()
 }
 
 /// Parses a timestamp from an Atom or JSON feed
 /// This should be an RFC-3339 formatted timestamp
 pub fn timestamp_rfc3339(text: &str) -> Option<DateTime<Utc>> {
     DateTime::parse_from_rfc3339(text.trim())
-        .map_or(None, |t| Some(t.with_timezone(&Utc)))
+        .map(|t| t.with_timezone(&Utc)).ok()
 }
 
 /// Generates a new UUID.


### PR DESCRIPTION
The [`map_or`](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or) method for `Result` was only added with rust 1.41. This is a problem for my flatpak build pipeline as the freedesktop sdk 19.08 is still on rust 1.39.

The `map_or()` in this case is basically used to convert a `Result` to an `Option`. The same can be achieved in a (imo) more readably fashion by modifying the value first with `map()` and then transforming the `Result` to `Option` with `ok()`.

So a win for everyone. Ability to build with older rust versions and code gets a bit simpler.