### PR TITLE
Less strict rfc3339 parsing

### DIFF
--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -4,7 +4,7 @@ use mime::Mime;
 #[cfg(test)]
 use crate::parser::util::timestamp_rfc2822_lenient;
 #[cfg(test)]
-use crate::parser::util::timestamp_rfc3339;
+use crate::parser::util::timestamp_rfc3339_lenient;
 
 /// Combined model for a syndication feed (i.e. RSS1, RSS 2, Atom, JSON Feed)
 ///
@@ -207,7 +207,7 @@ impl Feed {
     }
 
     pub fn updated_rfc3339(mut self, updated: &str) -> Self {
-        self.updated = timestamp_rfc3339(updated);
+        self.updated = timestamp_rfc3339_lenient(updated);
         self
     }
 }
@@ -330,7 +330,7 @@ impl Entry {
     }
 
     pub fn published_rfc3339(mut self, published: &str) -> Self {
-        self.published = timestamp_rfc3339(published);
+        self.published = timestamp_rfc3339_lenient(published);
         self
     }
 
@@ -355,7 +355,7 @@ impl Entry {
     }
 
     pub fn updated_rfc3339(mut self, updated: &str) -> Self {
-        self.updated = timestamp_rfc3339(updated);
+        self.updated = timestamp_rfc3339_lenient(updated);
         self
     }
 }

--- a/feed-rs/src/parser/atom/mod.rs
+++ b/feed-rs/src/parser/atom/mod.rs
@@ -6,7 +6,7 @@ use crate::model::{Category, Content, Entry, Feed, Generator, Image, Link, Perso
 use crate::parser::{ParseErrorKind, ParseFeedError, ParseFeedResult};
 use crate::util::attr_value;
 use crate::util::element_source::Element;
-use crate::parser::util::timestamp_rfc3339;
+use crate::parser::util::timestamp_rfc3339_lenient;
 
 #[cfg(test)]
 mod tests;
@@ -20,7 +20,7 @@ pub fn parse<R: Read>(root: Element<R>) -> ParseFeedResult<Feed> {
         match tag_name {
             "id" => if let Some(id) = child.child_as_text()? { feed.id = id },
             "title" => feed.title = handle_text(child)?,
-            "updated" => if let Some(text) = child.child_as_text()? { feed.updated = timestamp_rfc3339(&text) },
+            "updated" => if let Some(text) = child.child_as_text()? { feed.updated = timestamp_rfc3339_lenient(&text) },
 
             "author" => if let Some(person) = handle_person(child)? { feed.authors.push(person) }
             "link" => if let Some(link) = handle_link(child)? { feed.links.push(link) },
@@ -132,7 +132,7 @@ fn handle_entry<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Entry>> 
             // Extract the fields from the spec
             "id" => if let Some(id) = child.child_as_text()? { entry.id = id },
             "title" => entry.title = handle_text(child)?,
-            "updated" => if let Some(text) = child.child_as_text()? { entry.updated = timestamp_rfc3339(&text) },
+            "updated" => if let Some(text) = child.child_as_text()? { entry.updated = timestamp_rfc3339_lenient(&text) },
 
             "author" => if let Some(person) = handle_person(child)? { entry.authors.push(person) },
             "content" => entry.content = handle_content(child)?,
@@ -141,7 +141,7 @@ fn handle_entry<R: Read>(element: Element<R>) -> ParseFeedResult<Option<Entry>> 
 
             "category" => if let Some(category) = handle_category(child)? { entry.categories.push(category) },
             "contributor" => if let Some(person) = handle_person(child)? { entry.contributors.push(person) },
-            "published" => if let Some(text) = child.child_as_text()? { entry.published = timestamp_rfc3339(&text) },
+            "published" => if let Some(text) = child.child_as_text()? { entry.published = timestamp_rfc3339_lenient(&text) },
             "rights" => entry.rights = handle_text(child)?,
 
             // Nothing required for unknown elements

--- a/feed-rs/src/parser/json/mod.rs
+++ b/feed-rs/src/parser/json/mod.rs
@@ -4,7 +4,7 @@ use mime::Mime;
 
 use crate::model::{Category, Content, Entry, Feed, Image, Link, Person, Text};
 use crate::parser::{ParseFeedError, ParseFeedResult};
-use crate::parser::util::timestamp_rfc3339;
+use crate::parser::util::timestamp_rfc3339_lenient;
 
 #[cfg(test)]
 mod tests;
@@ -91,10 +91,10 @@ fn handle_item(ji: JsonItem) -> ParseFeedResult<Entry> {
     }
 
     if let Some(published) = ji.date_published {
-        entry.published = timestamp_rfc3339(&published);
+        entry.published = timestamp_rfc3339_lenient(&published);
     }
     if let Some(modified) = ji.date_modified {
-        entry.updated = timestamp_rfc3339(&modified);
+        entry.updated = timestamp_rfc3339_lenient(&modified);
     }
 
     if let Some(person) = handle_person(ji.author) { entry.authors.push(person); }


### PR DESCRIPTION
Should fix #43 
Inserts missing colon in timezone: `-0600` -> `-06:00`

Like I said I'm not that knowledgeable regarding regular expressions. But tests seem fine to me.