### PR TITLE
Publish 0.2.4

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feed-rs"
-version = "0.2.3"
+version = "0.2.4"
 edition = '2018'
 authors = ["Hiroki Kumamoto <kumabook@live.jp>", "Mark Pritchard <mpritcha@gmail.com>"]
 include = [


### PR DESCRIPTION
Sorry for the noise. But I'm trying to publish my application on Flathub and can't point to the github repo for that. Can we please get another point release containing the latest fixes?