### PR TITLE
Fix parsing atom:content with missing type

### DIFF
--- a/feed-rs/fixture/atom_publishing_spec_1.xml
+++ b/feed-rs/fixture/atom_publishing_spec_1.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Atom-Powered Robots Run Amok</title>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+    <author><name>John Doe</name></author>
+    <content>Some text.</content>
+  </entry>
+</feed>

--- a/feed-rs/src/parser/atom/tests.rs
+++ b/feed-rs/src/parser/atom/tests.rs
@@ -325,6 +325,7 @@ fn test_example_reddit() {
 }
 
 // Verify we can parse the example contained in the Atom specification
+// https://tools.ietf.org/html/rfc4287#section-1.1
 #[test]
 fn test_spec_1() {
     // Parse the feed
@@ -346,6 +347,32 @@ fn test_spec_1() {
             .summary(Text::new("Some text.".into()))
             .link(Link::new("http://example.org/2003/12/13/atom03".into())
                 .rel("alternate")));
+
+    // Check
+    assert_eq!(actual, expected);
+}
+
+// Verify we can parse Atom content elements without a type attribute
+// https://tools.ietf.org/html/rfc5023#section-9.2.1
+//
+// TODO fix parsing original example without feed root
+#[test]
+fn test_publishing_spec_1() {
+    // Parse the feed
+    let test_data = test::fixture_as_string("atom_publishing_spec_1.xml");
+    let actual = parser::parse(test_data.as_bytes()).unwrap()
+        .id(""); // Clear randomly generated UUID
+
+    // Expected feed
+    let expected = Feed::new(FeedType::Atom)
+        .entry(Entry::default()
+               .title(Text::new("Atom-Powered Robots Run Amok".into()))
+               .id("urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a")
+               .updated_rfc3339("2003-12-13T18:30:02Z")
+               .author(Person::new("John Doe".into()))
+               .content(Content::default()
+                        .content_type("text/plain")
+                        .body("Some text.")));
 
     // Check
     assert_eq!(actual, expected);


### PR DESCRIPTION
Currently, feed-rs fails to parse a feed without a `type` attribute on `atom:content`, however [RFC4287](https://tools.ietf.org/html/rfc4287#section-4.1.3.1) specifies that `text` should be used if neither `type` nor `src` is defined. 