### PR TITLE
Document requirement for source encoding

### DIFF
--- a/feed-rs/src/parser/mod.rs
+++ b/feed-rs/src/parser/mod.rs
@@ -94,6 +94,11 @@ impl fmt::Display for ParseErrorKind {
 ///
 /// * `input` - A source of content such as a string, file etc.
 ///
+/// NOTE: feed-rs uses the encoding attribute in the XML prolog to decode content.
+/// HTTP libraries (such as reqwest) provide a `text()` method which applies the content-encoding header and decodes the source into UTF-8.
+/// This then causes feed-rs to fail when it attempts to interpret the UTF-8 stream as a different character set.
+/// Instead, pass the raw, encoded source to feed-rs e.g. the `.bytes()` method if using reqwest.
+///
 /// # Examples
 ///
 /// ```

--- a/testurls/src/main.rs
+++ b/testurls/src/main.rs
@@ -8,11 +8,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for line in stdin.lock().lines() {
         let line = line?;
         print!("{}  ... ", line);
-        let xml = reqwest::blocking::get(&line)?.text()?;
+        let xml = reqwest::blocking::get(&line)?.bytes()?;
 
-        match parser::parse(xml.as_bytes()) {
+        match parser::parse(xml.as_ref()) {
             Ok(_feed) => println!("ok"),
-            Err(error) => println!("failed: {:?}\n{}\n-------------------------------------------------------------", error, xml),
+            Err(error) => println!("failed: {:?}\n{:?}\n-------------------------------------------------------------", error, xml),
         }
     }
 


### PR DESCRIPTION
To avoid double-decoding, feed-rs needs the source to be in the original
encoding. Add a note to the parse() method to explain this and update
testurls.

Fixes #69 