### PR TITLE
Support atom:entry documents

### DIFF
--- a/feed-rs/fixture/atom_entry_1.xml
+++ b/feed-rs/fixture/atom_entry_1.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom" xmlns:svnit="http://www.svnit.ac.in/coed/mtech/research/2009/khuba/">
+    <title type="text">Specifications</title>
+    <id>urn:uuid:988EF5C55CDEA24EDE1251744888912</id>
+    <updated>2009-08-31T18:55:12.569Z</updated>
+    <author>
+        <name>S. A. Khuba</name>
+    </author>
+    <category term="45121504" scheme="http://www.unspsc.org/UNv1111201" label="Digital Camera"/>
+    <svnit:Semantics available="OfflineAtURL">http://www.daman.nic.in/khuba/ontology/camera.owl</svnit:Semantics>
+    <contributor>
+        <name>Shri. S. A. Khuba</name>
+    </contributor>
+    <content type="text">1) Pixels 12.3 million Effective . 12) Weight is Approx. 840 g</content>
+    <summary type="text">This Atom Entry XML Doc publishes tech specifications of Nikon D300S Digital Camera</summary>
+</entry>

--- a/feed-rs/src/parser/atom/mod.rs
+++ b/feed-rs/src/parser/atom/mod.rs
@@ -11,7 +11,7 @@ use crate::xml::Element;
 mod tests;
 
 /// Parses an Atom feed into our model
-pub(crate) fn parse<R: BufRead>(root: Element<R>) -> ParseFeedResult<Feed> {
+pub(crate) fn parse_feed<R: BufRead>(root: Element<R>) -> ParseFeedResult<Feed> {
     let mut feed = Feed::new(FeedType::Atom);
     for child in root.children() {
         let child = child?;
@@ -36,6 +36,19 @@ pub(crate) fn parse<R: BufRead>(root: Element<R>) -> ParseFeedResult<Feed> {
             // Nothing required for unknown elements
             _ => {}
         }
+    }
+
+    Ok(feed)
+}
+
+/// Parses an Atom entry into our model
+///
+/// Note that the entry is wrapped in an empty Feed to keep the API consistent
+pub(crate) fn parse_entry<R: BufRead>(root: Element<R>) -> ParseFeedResult<Feed> {
+    let mut feed = Feed::new(FeedType::Atom);
+
+    if let Some(entry) = handle_entry(root)? {
+        feed.entries.push(entry)
     }
 
     Ok(feed)

--- a/feed-rs/src/parser/atom/tests.rs
+++ b/feed-rs/src/parser/atom/tests.rs
@@ -376,3 +376,30 @@ fn test_pub_spec_1() {
     // Check
     assert_eq!(actual, expected);
 }
+
+// Verify we can parse an Atom Entry (no feed)
+#[test]
+fn test_entry() {
+    let test_data = test::fixture_as_string("atom_entry_1.xml");
+    let actual = parser::parse(test_data.as_bytes()).unwrap()
+        .id("");
+
+    let expected = Feed::new(FeedType::Atom)
+        .entry(Entry::default()
+            .title(Text::new("Specifications".into()))
+            .id("urn:uuid:988EF5C55CDEA24EDE1251744888912")
+            .updated_rfc3339("2009-08-31T18:55:12.569Z")
+            .author(Person::new("S. A. Khuba".into()))
+            .category(Category::new("45121504")
+                .scheme("http://www.unspsc.org/UNv1111201")
+                .label("Digital Camera"))
+            .contributor(Person::new("Shri. S. A. Khuba"))
+            .content(Content::default()
+                .body("1) Pixels 12.3 million Effective . 12) Weight is Approx. 840 g")
+                .content_type("text/plain"))
+            .summary(Text::new("This Atom Entry XML Doc publishes tech specifications of Nikon D300S Digital Camera".into()))
+        );
+
+    // Check
+    assert_eq!(actual, expected);
+}

--- a/feed-rs/src/parser/mod.rs
+++ b/feed-rs/src/parser/mod.rs
@@ -184,7 +184,8 @@ fn parse_xml<R: BufRead>(source: R) -> ParseFeedResult<model::Feed> {
         // Dispatch to the correct parser
         let version = root.attr_value("version");
         match (root.name.as_str(), util::as_deref(&version)) {
-            ("feed", _) => return atom::parse(root),
+            ("feed", _) => return atom::parse_feed(root),
+            ("entry", _) => return atom::parse_entry(root),
             ("rss", Some("2.0")) => return rss2::parse(root),
             ("rss", Some("0.91")) | ("rss", Some("0.92")) => return rss0::parse(root),
             ("RDF", _) => return rss1::parse(root),


### PR DESCRIPTION
https://tools.ietf.org/html/rfc4287#section-2 indicates an Atom document
can be a Feed (atom:feed) or Entry (atom:entry). While not entirely
consistent with the concept of a _feed_ parser, its a simple addition
and supports CMSs using this old format.

Fixes #70 