### PR TITLE
[XML] Skip unparsable attributes

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -25,7 +25,7 @@ travis-ci = { repository = "feed-rs/feed-rs", branch = "master" }
 chrono = { version = "0.4" }
 lazy_static = "1.4"
 mime = "0.3"
-quick-xml = { version = "0.18", features = ["encoding"] }
+quick-xml = { version = "0.20", features = ["encoding"] }
 regex = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/feed-rs/src/xml/mod.rs
+++ b/feed-rs/src/xml/mod.rs
@@ -387,12 +387,15 @@ impl XmlEvent {
 
         // Parse the attributes
         let attributes = event.attributes()
-            .map(|a| {
-                let a = a.unwrap();
-                let name = reader.decode(a.key);
-                let value = reader.decode(a.value.as_ref());
+            .filter_map(|a| {
+                if let Ok(a) = a {
+                    let name = reader.decode(a.key);
+                    let value = reader.decode(a.value.as_ref());
 
-                NameValue { name: name.into(), value: value.into() }
+                    Some(NameValue { name: name.into(), value: value.into() })
+                } else {
+                    None
+                }
             })
             .collect::<Vec<NameValue>>();
 


### PR DESCRIPTION
Fixes #77 & bumped `quick-xml` to `0.20`

I went for
```
if let Ok(a) = a {
     let name = reader.decode(a.key);
     let value = reader.decode(a.value.as_ref());

     Some(NameValue { name: name.into(), value: value.into() })
} else {
     None
}
```
instead of something more compact like
```
a.ok().map(|a| NameValue { name: reader.decode(a.key).into(), value: reader.decode(a.value.as_ref()).into() })
```
as I think it is more readable.