### PR TITLE
Itunes podcast support

### DIFF
--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -785,6 +785,8 @@ pub struct MediaContent {
     /// Height and width
     pub height: Option<u32>,
     pub width: Option<u32>,
+    /// Duration the media plays
+    pub duration: Option<Duration>,
 }
 
 #[cfg(test)]
@@ -808,6 +810,11 @@ impl MediaContent {
         self.width = Some(width);
         self
     }
+
+    pub fn duration(mut self, duration: Duration) -> Self {
+        self.duration = Some(duration);
+        self
+    }
 }
 
 impl MediaContent {
@@ -817,6 +824,7 @@ impl MediaContent {
             content_type: None,
             height: None,
             width: None,
+            duration: None,
         }
     }
 }

--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -390,6 +390,11 @@ impl Entry {
         self.updated = timestamp_rfc3339_lenient(updated);
         self
     }
+
+    pub fn media(mut self, media: MediaObject) -> Self {
+        self.media.push(media);
+        self
+    }
 }
 
 /// Represents the category of a feed or entry

--- a/feed-rs/src/parser/atom/mod.rs
+++ b/feed-rs/src/parser/atom/mod.rs
@@ -272,7 +272,7 @@ fn handle_person<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Pers
 }
 
 // Directly handles an Atom <title>, <summary>, <rights> or <subtitle> element
-fn handle_text<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Text>> {
+pub(crate) fn handle_text<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Text>> {
     // Find type, defaulting to "text" if not present
     let type_attr = element.attributes.iter().find(|a| &a.name == "type").map_or("text", |a| a.value.as_str());
 

--- a/feed-rs/src/parser/itunes.rs
+++ b/feed-rs/src/parser/itunes.rs
@@ -1,4 +1,4 @@
-use crate::model::{Image, MediaCredit, MediaContent, MediaObject, MediaThumbnail};
+use crate::model::{Image, MediaContent, MediaCredit, MediaObject, MediaThumbnail};
 use crate::parser::atom::handle_text;
 use crate::parser::util::{if_some_then, parse_npt};
 use crate::parser::ParseFeedResult;

--- a/feed-rs/src/parser/itunes.rs
+++ b/feed-rs/src/parser/itunes.rs
@@ -1,0 +1,65 @@
+use crate::model::{Image, MediaCredit, MediaContent, MediaObject, MediaThumbnail};
+use crate::parser::atom::handle_text;
+use crate::parser::util::{if_some_then, parse_npt};
+use crate::parser::ParseFeedResult;
+use crate::xml::{Element, NS};
+use std::io::BufRead;
+use std::time::Duration;
+
+// Ref:
+// https://help.apple.com/itc/podcasts_connect/#/itcb54353390
+// https://www.feedforall.com/itune-tutorial-tags.htm
+
+// TODO:
+// - Handle <itunes:> elements for the whole feed in <channel>
+// - Add rating/adult support to MediaObject
+// - More elements like itunes:subtitle, itunes:episode etc.
+
+/*
+// Handles <itunes:explicit>
+fn handle_itunes_explicit<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<bool>> {
+    Ok(element.child_as_text()?.and_then(|text| match text.as_ref() {
+        "yes" | "true" => Some(true),
+        "no" | "false" | "clean" => Some(false),
+        _ => None,
+    }))
+}
+*/
+
+// Handles <itunes:image>
+fn handle_itunes_image<R: BufRead>(element: Element<R>) -> Option<MediaThumbnail> {
+    element.attr_value("href").map(|url| MediaThumbnail::new(Image::new(url)))
+}
+
+// Handles <itunes:duration>
+fn handle_itunes_duration<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Duration>> {
+    Ok(element.child_as_text()?.and_then(|text| parse_npt(&text)))
+}
+
+// Handles <itunes:author>
+fn handle_itunes_author<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<MediaCredit>> {
+    Ok(element.child_as_text()?.map(MediaCredit::new))
+}
+
+// Process <itunes> elements and turn them into something that looks like MediaRSS objects.
+// This is used to enrich <content:enclosure> in the RSS2 feed.
+pub(crate) fn handle_itunes_element<R: BufRead>(element: Element<R>, media_obj: &mut MediaObject) -> ParseFeedResult<()> {
+    match element.ns_and_tag() {
+        (Some(NS::Itunes), "title") => media_obj.title = handle_text(element)?,
+
+        (Some(NS::Itunes), "image") => if_some_then(handle_itunes_image(element), |thumbnail| media_obj.thumbnails.push(thumbnail)),
+
+        (Some(NS::Itunes), "duration") => if_some_then(handle_itunes_duration(element)?, |duration| {
+            media_obj.content.get_or_insert_with(MediaContent::new).duration = Some(duration)
+        }),
+
+        (Some(NS::Itunes), "author") => if_some_then(handle_itunes_author(element)?, |credit| media_obj.credits.push(credit)),
+
+        (Some(NS::Itunes), "summary") => media_obj.description = handle_text(element)?,
+
+        // Nothing required for unknown elements
+        _ => {}
+    }
+
+    Ok(())
+}

--- a/feed-rs/src/parser/mediarss.rs
+++ b/feed-rs/src/parser/mediarss.rs
@@ -1,13 +1,10 @@
 use std::io::BufRead;
 
 use crate::model::{Image, MediaCommunity, MediaContent, MediaCredit, MediaObject, MediaText, MediaThumbnail, Text};
-use crate::parser::util::{if_ok_then_some, if_some_then};
+use crate::parser::util::{if_ok_then_some, if_some_then, parse_npt};
 use crate::parser::{ParseErrorKind, ParseFeedError, ParseFeedResult};
 use crate::xml::{Element, NS};
 use mime::Mime;
-use regex::{Captures, Regex};
-use std::ops::Add;
-use std::time::Duration;
 
 // TODO find an RSS feed with media tags in it
 // TODO When an element appears at a shallow level, such as <channel> or <item>, it means that the element should be applied to every media object within its scope.
@@ -232,87 +229,4 @@ fn handle_text<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Text>>
         })
         // Need the text for a text element
         .ok_or(ParseFeedError::ParseError(ParseErrorKind::MissingContent("text")))
-}
-
-lazy_static! {
-    // Initialise the set of regular expressions we use to parse the NPT format
-    // See "3.6 Normal Play Time" in https://www.ietf.org/rfc/rfc2326.txt
-    static ref NPT_HHMMSS: Regex = {
-        // Extract hours (h), minutes (m), seconds (s) and fractional seconds (f)
-        Regex::new(r#"(?P<h>\d+):(?P<m>\d{2}):(?P<s>\d{2})(\.(?P<f>\d+))?"#).unwrap()
-    };
-    static ref NPT_SEC: Regex = {
-        // Extract seconds (s) and fractional seconds (f)
-        Regex::new(r#"(?P<s>\d+)(\.(?P<f>\d+))?"#).unwrap()
-    };
-}
-
-/// Parses "normal play time" per the RSS media spec
-/// NPT has a second or sub-second resolution. It is specified as H:M:S.h (npt-hhmmss) or S.h (npt-sec), where H=hours, M=minutes, S=second and h=fractions of a second.
-fn parse_npt(text: &str) -> Option<Duration> {
-    // Try npt-hhmmss format first
-    if let Some(captures) = NPT_HHMMSS.captures(text) {
-        let h = captures.name("h");
-        let m = captures.name("m");
-        let s = captures.name("s");
-
-        if let (Some(h), Some(m), Some(s)) = (h, m, s) {
-            // Parse the hours, minutes and seconds
-            let mut seconds = s.as_str().parse::<u64>().unwrap();
-            seconds += m.as_str().parse::<u64>().unwrap() * 60;
-            seconds += h.as_str().parse::<u64>().unwrap() * 3600;
-            let mut duration = Duration::from_secs(seconds);
-
-            // Add fractional seconds if present
-            duration = parse_npt_add_frac_sec(duration, captures);
-
-            return Some(duration);
-        }
-    }
-
-    // Next try npt-sec
-    if let Some(captures) = NPT_SEC.captures(text) {
-        if let Some(s) = captures.name("s") {
-            // Parse the seconds
-            let seconds = s.as_str().parse::<u64>().unwrap();
-            let mut duration = Duration::from_secs(seconds);
-
-            // Add fractional seconds if present
-            duration = parse_npt_add_frac_sec(duration, captures);
-
-            return Some(duration);
-        }
-    }
-
-    // Just drop it
-    None
-}
-
-// Adds the fractional seconds if present
-fn parse_npt_add_frac_sec(duration: Duration, captures: Captures) -> Duration {
-    if let Some(frac) = captures.name("f") {
-        let frac = frac.as_str();
-        let denom = 10f32.powi(frac.len() as i32);
-        let num = frac.parse::<f32>().unwrap();
-        let millis = (1000f32 * (num / denom)) as u64;
-        duration.add(Duration::from_millis(millis))
-    } else {
-        duration
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // Verify we can parse NPT times
-    #[test]
-    fn test_parse_npt() {
-        assert_eq!(parse_npt("12:05:35").unwrap(), Duration::from_secs(12 * 3600 + 5 * 60 + 35));
-        assert_eq!(
-            parse_npt("12:05:35.123").unwrap(),
-            Duration::from_millis(12 * 3600000 + 5 * 60000 + 35 * 1000 + 123)
-        );
-        assert_eq!(parse_npt("123.45").unwrap(), Duration::from_millis(123450));
-    }
 }

--- a/feed-rs/src/parser/mod.rs
+++ b/feed-rs/src/parser/mod.rs
@@ -14,6 +14,7 @@ mod rss0;
 mod rss1;
 mod rss2;
 
+pub(crate) mod itunes;
 pub(crate) mod mediarss;
 pub(crate) mod util;
 

--- a/feed-rs/src/parser/rss0/tests.rs
+++ b/feed-rs/src/parser/rss0/tests.rs
@@ -1,4 +1,4 @@
-use crate::model::{Content, Entry, Feed, FeedType, Image, Link, Person, Text};
+use crate::model::*;
 use crate::parser;
 use crate::util::test;
 
@@ -95,7 +95,11 @@ fn test_0_92_spec_1() {
                 .length(6666097)
                 .content_type("audio/mpeg"))
             .id(entry1.id.as_ref())     // not in source data
-            .updated(entry1.updated))   // not in source data
+            .updated(entry1.updated)   // not in source data
+            .media(MediaObject::new()
+                .content(MediaContent::new()
+                    .url("http://www.scripting.com/mp3s/theOtherOne.mp3")
+                    .content_type("audio/mpeg"))))
         .entry(Entry::default()
             .summary(Text::new("This is a test of a change I just made. Still diggin..".into()))
             .id(entry2.id.as_ref())     // not in source data

--- a/feed-rs/src/parser/rss2/mod.rs
+++ b/feed-rs/src/parser/rss2/mod.rs
@@ -3,7 +3,8 @@ use std::io::BufRead;
 use chrono::{DateTime, Utc};
 use mime::Mime;
 
-use crate::model::{Category, Content, Entry, Feed, FeedType, Generator, Image, Link, Person, Text};
+use crate::model::{Category, Content, Entry, Feed, FeedType, Generator, Image, Link, MediaContent, MediaObject, Person, Text};
+use crate::parser::itunes::handle_itunes_element;
 use crate::parser::util::{if_ok_then_some, if_some_then, timestamp_rfc2822_lenient};
 use crate::parser::{util, ParseErrorKind, ParseFeedError, ParseFeedResult};
 use crate::xml::{Element, NS};
@@ -179,6 +180,9 @@ fn handle_item<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Entry>
     // So we will keep content:encoded aside during the parse, and use it as the content if we didn't find an enclosure
     let mut content_encoded: Option<Text> = None;
 
+    // Create a default MediaRSS content object for <itunes> elements.
+    let mut media_obj = MediaObject::new();
+
     for child in element.children() {
         let child = child?;
         match child.ns_and_tag() {
@@ -202,13 +206,24 @@ fn handle_item<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Entry>
 
             (Some(NS::DublinCore), "creator") => if_some_then(child.child_as_text()?, |name| entry.authors.push(Person::new(&name))),
 
+            (Some(NS::Itunes), _) => handle_itunes_element(child, &mut media_obj)?,
+
             // Nothing required for unknown elements
             _ => {}
         }
     }
 
-    // Use content_encoded if we didn't find an enclosure above
-    if entry.content.is_none() {
+    // If we have an enclosure insert a media element based on (optional)
+    // itunes data.
+    if let Some(ref content) = entry.content {
+        if let Some(ref src) = content.src {
+            let media_content = media_obj.content.get_or_insert_with(MediaContent::new);
+            media_content.content_type = Some(content.content_type.clone());
+            media_content.url = Some(src.clone().href);
+            entry.media.push(media_obj);
+        }
+    } else {
+        // Use content_encoded if we didn't find an enclosure above
         if let Some(ce) = content_encoded {
             entry.content = Some(Content {
                 body: Some(ce.content),

--- a/feed-rs/src/parser/rss2/tests.rs
+++ b/feed-rs/src/parser/rss2/tests.rs
@@ -1,4 +1,4 @@
-use crate::model::{Category, Content, Entry, Feed, FeedType, Generator, Image, Link, Person, Text};
+use crate::model::*;
 use crate::parser;
 use crate::util::test;
 
@@ -64,7 +64,11 @@ fn test_example_2() {
                 .content_type("image/jpeg"))
             .id("\n                http://www.nasa.gov/press-release/nasa-television-to-broadcast-space-station-departure-of-cygnus-cargo-ship\n            ")
             .published_rfc2822("Thu, 01 Aug 2019 16:15 EDT")
-            .updated(actual.updated));
+            .updated(actual.updated)
+            .media(MediaObject::new()
+                .content(MediaContent::new()
+                    .url("http://www.nasa.gov/sites/default/files/styles/1x1_cardfeed/public/thumbnails/image/47616261882_4bb534d293_k.jpg?itok=Djjjs81t")
+                    .content_type("image/jpeg"))));
 
     // Check
     assert_eq!(actual, expected);

--- a/feed-rs/src/xml/mod.rs
+++ b/feed-rs/src/xml/mod.rs
@@ -322,6 +322,8 @@ pub(crate) enum NS {
     DublinCore,
     // http://search.yahoo.com/mrss/
     MediaRSS,
+    // http://www.itunes.com/dtds/podcast-1.0.dtd
+    Itunes,
 }
 
 impl NS {
@@ -330,6 +332,7 @@ impl NS {
             "http://purl.org/rss/1.0/modules/content/" => Some(NS::Content),
             "http://purl.org/dc/elements/1.1/" => Some(NS::DublinCore),
             "http://search.yahoo.com/mrss/" => Some(NS::MediaRSS),
+            "http://www.itunes.com/dtds/podcast-1.0.dtd" => Some(NS::Itunes),
             _ => None,
         }
     }


### PR DESCRIPTION
I am thinking about using this library for some CLI podcast stuff. For this reason I started implementing some of the `<itunes:>` tags that are often used for this. I am not sure if there is a proper spec, but I found page: https://help.apple.com/itc/podcasts_connect/#/itcb54353390. Right now I am using https://feeds.npr.org/510289/podcast.xml for testing.

I tried to imagine what I thought support for the RSS media spec would look like. In  #68 @markpritchard mentioned a branch for that, but I haven't actually seen it.

This is still missing tests and maybe this should be based on #68 as I said. 