### PR TITLE
ID from URI

### DIFF
--- a/feed-rs/fixture/rss_0.91_missing_id.xml
+++ b/feed-rs/fixture/rss_0.91_missing_id.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<rss version="0.91">
+    <channel>
+        <title>Servicio de Personal - Ingreso - Diputación de valencia</title>
+        <link>http://www.dival.es/personal</link>
+        <description><![CDATA[Anuncios del Servicio de Personal - Sistemas de Ingreso, de la Diputación de Valencia]]></description>
+        <language>es-ES</language>
+        <item>
+            <title>Oferta de Empleo Público // 3 PROFESOR/A TÉCNICO/A (INGENIE. TÉC. FORESTAL) 17/17</title>
+            <description><![CDATA[Publicado el <B>14-05-2021</b> resultado de  <b>calificaciones 2º ej</b> en los tablones de anuncios. <A HREF='https://web01.dival.es/personal/reponodoc/NOTAS 2EJ 17_17.pdf'>Descárguelo aquí</A>]]></description>
+        </item>
+    </channel>
+</rss>

--- a/feed-rs/src/parser/mod.rs
+++ b/feed-rs/src/parser/mod.rs
@@ -147,7 +147,7 @@ pub fn parse_with_uri<R: Read>(source: R, uri: Option<&str>) -> ParseFeedResult<
 
     // Post processing as required
     if let Ok(mut feed) = result {
-        assign_missing_ids(&mut feed);
+        assign_missing_ids(&mut feed, uri);
 
         Ok(feed)
     } else {
@@ -156,14 +156,14 @@ pub fn parse_with_uri<R: Read>(source: R, uri: Option<&str>) -> ParseFeedResult<
 }
 
 // Assigns IDs to missing feed + entries as required
-fn assign_missing_ids(feed: &mut model::Feed) {
+fn assign_missing_ids(feed: &mut model::Feed, uri: Option<&str>) {
     if feed.id.is_empty() {
-        feed.id = create_id(&feed.links, &feed.title);
+        feed.id = create_id(&feed.links, &feed.title, uri);
     }
 
     for entry in feed.entries.iter_mut() {
         if entry.id.is_empty() {
-            entry.id = create_id(&entry.links, &entry.title);
+            entry.id = create_id(&entry.links, &entry.title, uri);
         }
     }
 }
@@ -172,9 +172,10 @@ const LINK_HASH_KEY1: u64 = 0x5d78_4074_2887_2d60;
 const LINK_HASH_KEY2: u64 = 0x90ee_ca4c_90a5_e228;
 
 // Creates a unique ID from the first link, or a UUID if no links are available
-fn create_id(links: &[model::Link], title: &Option<model::Text>) -> String {
-    // Generate a stable ID for this item based on the first link
+fn create_id(links: &[model::Link], title: &Option<model::Text>, uri: Option<&str>) -> String {
     if let Some(link) = links.iter().next() {
+
+        // Generate a stable ID for this item based on the first link
         let mut hasher = SipHasher::new_with_keys(LINK_HASH_KEY1, LINK_HASH_KEY2);
         hasher.write(link.href.as_bytes());
         if let Some(title) = title {
@@ -182,6 +183,16 @@ fn create_id(links: &[model::Link], title: &Option<model::Text>) -> String {
         }
         let hash = hasher.finish128();
         format!("{:x}{:x}", hash.h1, hash.h2)
+
+    } else if let (Some(uri), Some(title)) = (uri, title) {
+
+        // if no links were provided by the feed use the optional URI passed by the caller
+        let mut hasher = SipHasher::new_with_keys(LINK_HASH_KEY1, LINK_HASH_KEY2);
+        hasher.write(uri.as_bytes());
+        hasher.write(title.content.as_bytes());
+        let hash = hasher.finish128();
+        format!("{:x}{:x}", hash.h1, hash.h2)
+
     } else {
         // Generate a UUID as last resort
         util::uuid_gen()

--- a/feed-rs/src/parser/mod.rs
+++ b/feed-rs/src/parser/mod.rs
@@ -174,7 +174,6 @@ const LINK_HASH_KEY2: u64 = 0x90ee_ca4c_90a5_e228;
 // Creates a unique ID from the first link, or a UUID if no links are available
 fn create_id(links: &[model::Link], title: &Option<model::Text>, uri: Option<&str>) -> String {
     if let Some(link) = links.iter().next() {
-
         // Generate a stable ID for this item based on the first link
         let mut hasher = SipHasher::new_with_keys(LINK_HASH_KEY1, LINK_HASH_KEY2);
         hasher.write(link.href.as_bytes());
@@ -183,16 +182,13 @@ fn create_id(links: &[model::Link], title: &Option<model::Text>, uri: Option<&st
         }
         let hash = hasher.finish128();
         format!("{:x}{:x}", hash.h1, hash.h2)
-
     } else if let (Some(uri), Some(title)) = (uri, title) {
-
         // if no links were provided by the feed use the optional URI passed by the caller
         let mut hasher = SipHasher::new_with_keys(LINK_HASH_KEY1, LINK_HASH_KEY2);
         hasher.write(uri.as_bytes());
         hasher.write(title.content.as_bytes());
         let hash = hasher.finish128();
         format!("{:x}{:x}", hash.h1, hash.h2)
-
     } else {
         // Generate a UUID as last resort
         util::uuid_gen()

--- a/feed-rs/src/parser/rss0/tests.rs
+++ b/feed-rs/src/parser/rss0/tests.rs
@@ -71,7 +71,10 @@ fn test_0_91_missing_id() {
     assert_eq!(feed.id, "f17ff7bbd6c6bd74733bbf47cb8592d5");
     assert_eq!(feed.title.unwrap().content, "Servicio de Personal - Ingreso - Diputación de valencia");
     assert_eq!(feed.entries[0].id, "a30a565dde9ff8cb7063e0e8ad5db62");
-    assert_eq!(feed.entries[0].title.as_ref().unwrap().content, "Oferta de Empleo Público // 3 PROFESOR/A TÉCNICO/A (INGENIE. TÉC. FORESTAL) 17/17");
+    assert_eq!(
+        feed.entries[0].title.as_ref().unwrap().content,
+        "Oferta de Empleo Público // 3 PROFESOR/A TÉCNICO/A (INGENIE. TÉC. FORESTAL) 17/17"
+    );
 }
 
 // Trimmed example of RSS 0.92 from the specification at http://backend.userland.com/rss092

--- a/feed-rs/src/parser/rss0/tests.rs
+++ b/feed-rs/src/parser/rss0/tests.rs
@@ -63,6 +63,17 @@ fn test_0_91_encoding_2() {
     assert!(feed.entries[0].summary.as_ref().unwrap().content.contains("prevenção"));
 }
 
+// Verifies that we can handle feeds without IDs and links
+#[test]
+fn test_0_91_missing_id() {
+    let test_data = test::fixture_as_raw("rss_0.91_missing_id.xml");
+    let feed = parser::parse_with_uri(test_data.as_slice(), Some("https://feeds.feedburner.com/ingreso_dival")).unwrap();
+    assert_eq!(feed.id, "f17ff7bbd6c6bd74733bbf47cb8592d5");
+    assert_eq!(feed.title.unwrap().content, "Servicio de Personal - Ingreso - Diputación de valencia");
+    assert_eq!(feed.entries[0].id, "a30a565dde9ff8cb7063e0e8ad5db62");
+    assert_eq!(feed.entries[0].title.as_ref().unwrap().content, "Oferta de Empleo Público // 3 PROFESOR/A TÉCNICO/A (INGENIE. TÉC. FORESTAL) 17/17");
+}
+
 // Trimmed example of RSS 0.92 from the specification at http://backend.userland.com/rss092
 #[test]
 fn test_0_92_spec_1() {

--- a/testurls/src/main.rs
+++ b/testurls/src/main.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         print!("{}  ... ", line);
         let xml = reqwest::blocking::get(&line)?.bytes()?;
 
-        match parser::parse(xml.as_ref()) {
+        match parser::parse_with_uri(xml.as_ref(), Some(&line)) {
             Ok(_feed) => println!("ok"),
             Err(error) => println!("failed: {:?}\n{:?}\n-------------------------------------------------------------", error, xml),
         }


### PR DESCRIPTION
Use the URI + title to generate an ID for those feeds that do not provide an ID (e.g. RSS 0.91)