### PR TITLE
Update dependencies

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -23,12 +23,12 @@ travis-ci = { repository = "feed-rs/feed-rs", branch = "master" }
 
 [dependencies]
 chrono = { version = "0.4" }
-lazy_static = "1.4"
+lazy_static = "1"
 mime = "0.3"
-quick-xml = { version = "0.20", features = ["encoding"] }
-regex = "1.4"
+quick-xml = { version = "0.22", features = ["encoding"] }
+regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 siphasher = "0.3"
-url = "2.2"
+url = "2"
 uuid = { version = "0.8", features = ["v4"] }

--- a/feed-rs/src/xml/mod.rs
+++ b/feed-rs/src/xml/mod.rs
@@ -263,17 +263,12 @@ impl<R: BufRead> SourceState<R> {
                     return Ok(Some(XmlEvent::end(e, reader)));
                 }
 
-                // Text
-                Event::Text(ref t) => {
+                // Text or CData
+                Event::Text(ref t) | Event::CData(ref t) => {
                     let event = XmlEvent::text(t, reader);
                     if let Ok(Some(ref _t)) = event {
                         return event;
                     }
-                }
-
-                // CData
-                Event::CData(ref t) => {
-                    return Ok(Some(XmlEvent::text_from_cdata(t, reader)));
                 }
 
                 // The end of the document
@@ -508,12 +503,6 @@ impl XmlEvent {
         } else {
             Ok(Some(XmlEvent::Text(text)))
         }
-    }
-
-    // Creates a new event corresponding to an XML CData tag
-    fn text_from_cdata<R: BufRead>(text: &BytesText, reader: &Reader<R>) -> XmlEvent {
-        let text = reader.decode(text);
-        XmlEvent::Text(text.into())
     }
 }
 

--- a/testurls/Cargo.toml
+++ b/testurls/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 feed-rs = { path = "../feed-rs" }
-reqwest = { version = "0.10", features = ["blocking"] }
+reqwest = { version = "0.11", features = ["blocking"] }


### PR DESCRIPTION
Fix text failure with quick-xml upgrade (now encodes CData, so we need
to decode entities).