### PR TITLE
Ignore unknown NS

### DIFF
--- a/feed-rs/fixture/rss_2.0_spreaker.xml
+++ b/feed-rs/fixture/rss_2.0_spreaker.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+     xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0" xmlns:atom="http://www.w3.org/2005/Atom"
+     version="2.0">
+    <channel>
+        <title>Lwowska Fala | Radio Katowice</title>
+        <link>https://www.spreaker.com/show/lwowska-fala-radio-katowice</link>
+        <description>
+            <![CDATA[Lwowska Fala, audycja, która ocala od zapomnienia kresową tradycję i kulturę, lwowski humor i piosenkę, ale także prawdę o losach Polaków, tragicznie splecionych z wojną i okupacją na Ziemiach Wschodnich Rzeczypospolitej. Zaprasza Danuta Skalska.]]></description>
+        <atom:link href="https://www.spreaker.com/show/4273892/episodes/feed" rel="self" type="application/rss+xml"/>
+        <language>pl</language>
+        <category>Society &amp; Culture</category>
+        <copyright>Copyright Radio Katowice S.A.</copyright>
+        <image>
+            <url>
+                https://d3wo5wojvuv7l.cloudfront.net/t_rss_itunes_square_1400/images.spreaker.com/original/0dcd53afca70854beb456079fa25d3f1.jpg
+            </url>
+            <title>Lwowska Fala | Radio Katowice</title>
+            <link>https://www.spreaker.com/show/lwowska-fala-radio-katowice</link>
+        </image>
+        <lastBuildDate>Mon, 06 Sep 2021 08:11:32 +0000</lastBuildDate>
+        <itunes:author>Radio Katowice S.A.</itunes:author>
+        <itunes:owner>
+            <itunes:name>Radio Katowice S.A.</itunes:name>
+            <itunes:email>feeds@spreaker.com</itunes:email>
+        </itunes:owner>
+        <itunes:image
+                href="https://d3wo5wojvuv7l.cloudfront.net/t_rss_itunes_square_1400/images.spreaker.com/original/0dcd53afca70854beb456079fa25d3f1.jpg"/>
+        <itunes:subtitle>Lwowska Fala, audycja, która ocala od zapomnienia kresową tradycję i kulturę, lwowski humor i
+            piosenkę, ale także prawdę o losach Polaków, tragicznie splecionych z wojną i okupacją na Ziemiach
+            Wschodnich Rzeczypospolitej. Zaprasza Danuta Skalska.
+        </itunes:subtitle>
+        <itunes:summary>
+            <![CDATA[Lwowska Fala, audycja, która ocala od zapomnienia kresową tradycję i kulturę, lwowski humor i piosenkę, ale także prawdę o losach Polaków, tragicznie splecionych z wojną i okupacją na Ziemiach Wschodnich Rzeczypospolitej. Zaprasza Danuta Skalska.]]></itunes:summary>
+        <itunes:category text="Society &amp; Culture"/>
+        <itunes:explicit>clean</itunes:explicit>
+        <itunes:type>episodic</itunes:type>
+        <googleplay:author>Radio Katowice S.A.</googleplay:author>
+        <googleplay:image
+                href="https://d3wo5wojvuv7l.cloudfront.net/t_rss_itunes_square_1400/images.spreaker.com/original/0dcd53afca70854beb456079fa25d3f1.jpg"/>
+        <googleplay:email>feeds@spreaker.com</googleplay:email>
+        <googleplay:description>Lwowska Fala, audycja, która ocala od zapomnienia kresową tradycję i kulturę, lwowski
+            humor i piosenkę, ale także prawdę o losach Polaków, tragicznie splecionych z wojną i okupacją na Ziemiach
+            Wschodnich Rzeczypospolitej. Zaprasza Danuta Skalska.
+        </googleplay:description>
+        <googleplay:category text="Society &amp; Culture"/>
+        <googleplay:explicit>No</googleplay:explicit>
+        <item>
+            <title>Lwowska Fala odc. 78 Wrzesień 1939 | Radio Katowice</title>
+            <link>https://www.spreaker.com/user/radio_katowice/09-05-dopo-8-10-lwowska-fala</link>
+            <description>
+                <![CDATA[W audycji: Pamięć września 1939. Spotkanie z Marszałkiem J. Chełstowskim. Lwów w oczach Ślązaków. Byliśmy pod Zadwórzem. Wio na piechotę – do Lwowa!]]></description>
+            <guid isPermaLink="false">https://api.spreaker.com/episode/46395247</guid>
+            <pubDate>Mon, 06 Sep 2021 08:11:31 +0000</pubDate>
+            <enclosure url="https://api.spreaker.com/download/episode/46395247/09_05_dopo_8_10_lwowska_fala.mp3"
+                       length="49252772" type="audio/mpeg"/>
+            <itunes:author>Radio Katowice S.A.</itunes:author>
+            <itunes:subtitle>W audycji: Pamięć września 1939. Spotkanie z Marszałkiem J. Chełstowskim. Lwów w oczach
+                Ślązaków. Byliśmy pod Zadwórzem. Wio na piechotę – do Lwowa!
+            </itunes:subtitle>
+            <itunes:summary>
+                <![CDATA[W audycji: Pamięć września 1939. Spotkanie z Marszałkiem J. Chełstowskim. Lwów w oczach Ślązaków. Byliśmy pod Zadwórzem. Wio na piechotę – do Lwowa!]]></itunes:summary>
+            <itunes:duration>3079</itunes:duration>
+            <itunes:keywords>fala,kresy,lwow,lwowska</itunes:keywords>
+            <itunes:explicit>clean</itunes:explicit>
+            <itunes:image
+                    href="https://d3wo5wojvuv7l.cloudfront.net/t_rss_itunes_square_1400/images.spreaker.com/original/0dcd53afca70854beb456079fa25d3f1.jpg"/>
+            <itunes:episodeType>full</itunes:episodeType>
+            <googleplay:author>Radio Katowice S.A.</googleplay:author>
+            <googleplay:description>W audycji: Pamięć września 1939. Spotkanie z Marszałkiem J. Chełstowskim. Lwów w
+                oczach Ślązaków. Byliśmy pod Zadwórzem. Wio na piechotę – do Lwowa!
+            </googleplay:description>
+            <googleplay:image
+                    href="https://d3wo5wojvuv7l.cloudfront.net/t_rss_itunes_square_1400/images.spreaker.com/original/0dcd53afca70854beb456079fa25d3f1.jpg"/>
+            <googleplay:explicit>No</googleplay:explicit>
+        </item>
+    </channel>
+</rss>

--- a/feed-rs/src/parser/rss2/tests.rs
+++ b/feed-rs/src/parser/rss2/tests.rs
@@ -368,6 +368,17 @@ fn test_spiegel() {
     assert_eq!(actual, expected);
 }
 
+// Check that we ignore tags in unknown namespaces
+// In the case of this feed, we ignore googleplay, and don't overwrite the RSS2 image
+#[test]
+fn test_spreaker_ignore_unknown_ns() {
+    let test_data = test::fixture_as_raw("rss_2.0_spreaker.xml");
+    let feed = parser::parse(test_data.as_slice()).unwrap();
+
+    // Feed should have a logo
+    assert!(feed.logo.is_some());
+}
+
 // Verifies that we can handle mixed MediaRSS and itunes/enclosure
 #[test]
 fn test_bbc() {

--- a/feed-rs/src/xml/mod.rs
+++ b/feed-rs/src/xml/mod.rs
@@ -378,24 +378,30 @@ impl<'a, R: BufRead> Iterator for ElementIter<'a, R> {
 /// Set of automatically recognised namespaces
 #[derive(Debug, PartialEq)]
 pub(crate) enum NS {
-    // http://purl.org/rss/1.0/modules/content/
+    // Namespaces we do not support are treated as this special case, to avoid processing content incorrectly
+    Unknown,
+    // Extensions
     Content,
-    // http://purl.org/dc/elements/1.1/
     DublinCore,
-    // http://search.yahoo.com/mrss/
     MediaRSS,
-    // http://www.itunes.com/dtds/podcast-1.0.dtd
     Itunes,
 }
 
 impl NS {
     fn parse(s: &str) -> Option<NS> {
         match s {
+            // Feed namespaces (Atom, RSS) are mapped on to None, since they are the base NS
+            // This handles documents where it is explicit, and implicit
+            "http://www.w3.org/2005/Atom" | "http://purl.org/rss/1.0/" => None,
+
+            // Extension namespaces
             "http://purl.org/rss/1.0/modules/content/" => Some(NS::Content),
             "http://purl.org/dc/elements/1.1/" => Some(NS::DublinCore),
             "http://search.yahoo.com/mrss/" => Some(NS::MediaRSS),
             "http://www.itunes.com/dtds/podcast-1.0.dtd" => Some(NS::Itunes),
-            _ => None,
+
+            // Everything else is ignored
+            _ => Some(NS::Unknown),
         }
     }
 }


### PR DESCRIPTION
Tags such as "image" are used across multiple namespaces (Atom, RSS,
iTunes). Also used in namespaces we do not support (Google Play).

This commit fixes the behaviour where tags from an unsupported NS are
treated as if they were the root NS (e.g. a tag within the RSS NS), and
could potentially overwrite / corrupt content.

Tags in an unknown NS are now ignored.

Fixes #125