### PR TITLE
Treat <content:encoded> and <description> as HTML.

### DIFF
--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -282,6 +282,8 @@ pub struct Entry {
     /// * Atom (recommended): Conveys a short summary, abstract, or excerpt of the entry.
     /// * RSS 1+2 (optional): The item synopsis.
     /// * JSON Feed: the summary for the item, or the text content if no summary is provided and both text and html content are specified
+    ///
+    /// Warning: Some feeds (especially RSS) use significant whitespace in this field even in cases where it should be considered HTML. Consider rendering this field in a way that preserves whitespace-based formatting such as a double-newline to separate paragraphs.
     pub summary: Option<Text>,
 
     /// Structured classification of the item
@@ -996,6 +998,14 @@ impl Text {
     pub(crate) fn new(content: String) -> Text {
         Text {
             content_type: mime::TEXT_PLAIN,
+            src: None,
+            content,
+        }
+    }
+
+    pub(crate) fn html(content: String) -> Text {
+        Text {
+            content_type: mime::TEXT_HTML,
             src: None,
             content,
         }

--- a/feed-rs/src/parser/rss0/tests.rs
+++ b/feed-rs/src/parser/rss0/tests.rs
@@ -31,13 +31,13 @@ fn test_0_91_spec_1() {
         .entry(Entry::default()
             .title(Text::new("Giving the world a pluggable Gnutella".into()))
             .link(Link::new("http://writetheweb.com/read.php?item=24", None))
-            .summary(Text::new("WorldOS is a framework on which to build programs that work like Freenet or Gnutella -allowing\n                distributed applications using peer-to-peer routing.\n            ".into()))
+            .summary(Text::html("WorldOS is a framework on which to build programs that work like Freenet or Gnutella -allowing\n                distributed applications using peer-to-peer routing.\n            ".into()))
             .id(entry0.id.as_ref())     // not in source data
             .updated(entry0.updated))   // not in source data
         .entry(Entry::default()
             .title(Text::new("Syndication discussions hot up".into()))
             .link(Link::new("http://writetheweb.com/read.php?item=23", None))
-            .summary(Text::new("After a period of dormancy, the Syndication mailing list has become active again, with\n                contributions from leaders in traditional media and Web syndication.\n            ".into()))
+            .summary(Text::html("After a period of dormancy, the Syndication mailing list has become active again, with\n                contributions from leaders in traditional media and Web syndication.\n            ".into()))
             .id(entry1.id.as_ref())     // not in source data
             .updated(entry1.updated)); // not in source data
 
@@ -97,11 +97,11 @@ fn test_0_92_spec_1() {
         .contributor(Person::new("managingEditor").email("dave@userland.com (Dave Winer)"))
         .contributor(Person::new("webMaster").email("dave@userland.com (Dave Winer)"))
         .entry(Entry::default()
-            .summary(Text::new("Kevin Drennan started a <a href=\"http://deadend.editthispage.com/\">Grateful\n                Dead Weblog</a>. Hey it's cool, he even has a <a href=\"http://deadend.editthispage.com/directory/61\">directory</a>.\n                <i>A Frontier 7 feature.</i>\n            ".into()))
+            .summary(Text::html("Kevin Drennan started a <a href=\"http://deadend.editthispage.com/\">Grateful\n                Dead Weblog</a>. Hey it's cool, he even has a <a href=\"http://deadend.editthispage.com/directory/61\">directory</a>.\n                <i>A Frontier 7 feature.</i>\n            ".into()))
             .id(entry0.id.as_ref())     // not in source data
             .updated(entry0.updated))   // not in source data
         .entry(Entry::default()
-            .summary(Text::new("<a href=\"http://arts.ucsc.edu/GDead/AGDL/other1.html\">The Other One</a>,
+            .summary(Text::html("<a href=\"http://arts.ucsc.edu/GDead/AGDL/other1.html\">The Other One</a>,
                 live instrumental, One From The Vault. Very rhythmic very spacy, you can listen to it many times, and
                 enjoy something new every time.\n            ".into()))
             .id(entry1.id.as_ref())     // not in source data
@@ -112,7 +112,7 @@ fn test_0_92_spec_1() {
                     .content_type("audio/mpeg")
                     .size(6666097))))
         .entry(Entry::default()
-            .summary(Text::new("This is a test of a change I just made. Still diggin..".into()))
+            .summary(Text::html("This is a test of a change I just made. Still diggin..".into()))
             .id(entry2.id.as_ref())     // not in source data
             .updated(entry2.updated)); // not in source data
 

--- a/feed-rs/src/parser/rss1/tests.rs
+++ b/feed-rs/src/parser/rss1/tests.rs
@@ -60,6 +60,13 @@ fn test_example_2() {
         .as_ref()
         .unwrap()
         .starts_with("This morning I saw two things that were Microsoft "));
+    // content media type should be text/html.
+    assert_eq!(feed.entries[0]
+        .content
+        .as_ref()
+        .unwrap()
+        .content_type,
+        "text/html");
 }
 
 // Example 1 from the spec at https://validator.w3.org/feed/docs/rss1.html

--- a/feed-rs/src/parser/rss2/mod.rs
+++ b/feed-rs/src/parser/rss2/mod.rs
@@ -183,7 +183,7 @@ fn handle_content_encoded<R: BufRead>(element: Element<R>) -> ParseFeedResult<Op
 
     Ok(element.children_as_string()?.map(|string| Content {
         body: Some(string),
-        content_type: mime::TEXT_PLAIN,
+        content_type: mime::TEXT_HTML,
         src,
         ..Default::default()
     }))

--- a/feed-rs/src/parser/rss2/tests.rs
+++ b/feed-rs/src/parser/rss2/tests.rs
@@ -24,7 +24,7 @@ fn test_example_1() {
         .entry(
             Entry::default()
                 .title(Text::new("Example entry".into()))
-                .summary(Text::new("Here is some text containing an interesting description.".into()))
+                .summary(Text::html("Here is some text containing an interesting description.".into()))
                 .link(Link::new("http://www.example.com/blog/post/1", None))
                 .id("7bd204c6-1655-4c27-aeee-53f933c5395f")
                 .published_rfc2822("Sun, 06 Sep 2009 16:20:00 +0000")
@@ -57,7 +57,7 @@ fn test_example_2() {
         .entry(Entry::default()
             .title(Text::new("NASA Television to Broadcast Space Station Departure of Cygnus Cargo Ship".into()))
             .link(Link::new("\n                http://www.nasa.gov/press-release/nasa-television-to-broadcast-space-station-departure-of-cygnus-cargo-ship\n            ", None))
-            .summary(Text::new(r#"More than three months after delivering several tons of supplies and scientific experiments to
+            .summary(Text::html(r#"More than three months after delivering several tons of supplies and scientific experiments to
                 the International Space Station, Northrop Grumman’s Cygnus cargo spacecraft, the SS Roger Chaffee, will
                 depart the orbiting laboratory Tuesday, Aug. 6.
             "#.to_owned()))
@@ -95,7 +95,7 @@ fn test_example_3() {
             .link(Link::new("\n                https://www.newyorker.com/news/q-and-a/how-a-historian-uncovered-ronald-reagans-racist-remarks-to-richard-nixon\n            ", None))
             .id("5d420f3abfe6c20008d5eaad")
             .author(Person::new("Isaac Chotiner".into()))
-            .summary(Text::new("Isaac Chotiner talks with the historian Tim Naftali, who published the text and audio of a\n                taped call, from 1971, in which Reagan described the African delegates to the U.N. in luridly racist\n                terms.\n            ".into()))
+            .summary(Text::html("Isaac Chotiner talks with the historian Tim Naftali, who published the text and audio of a\n                taped call, from 1971, in which Reagan described the African delegates to the U.N. in luridly racist\n                terms.\n            ".into()))
             .category(Category::new("News / Q. & A."))
             .published_rfc2822("Fri, 02 Aug 2019 15:35:34 +0000")
             .updated(actual.updated)
@@ -133,9 +133,10 @@ fn test_example_4() {
             .category(Category::new("Minor World Earthquakes Magnitude -3.9"))
             .category(Category::new("Spárti"))
             .id("\n                http://www.earthquakenewstoday.com/2019/08/06/minor-earthquake-3-5-mag-was-detected-near-aris-in-greece/\n            ")
-            .summary(Text::new("\n                A minor earthquake magnitude 3.5 (ml/mb) strikes near Kalamáta, Trípoli, Pýrgos, Spárti, Filiatrá, Messíni, Greece on Tuesday.".into()))
+            .summary(Text::html("\n                A minor earthquake magnitude 3.5 (ml/mb) strikes near Kalamáta, Trípoli, Pýrgos, Spárti, Filiatrá, Messíni, Greece on Tuesday.".into()))
             .content(Content::default()
-                .body("<p><img class='size-full alignleft' title='Earthquake location 37.102S, 21.9072W' alt='Earthquake location 37.102S, 21.9072W' src='http://www.earthquakenewstoday.com/wp-content/uploads/35_20.jpg' width='146' height='146' />A minor earthquake with magnitude 3.5 (ml/mb) was detected on Tuesday, 8 kilometers (5 miles) from Aris in Greece.Exact location of event, depth 10 km, 21.9072&deg; East, 37.102&deg; North. </p>"))
+                .body("<p><img class='size-full alignleft' title='Earthquake location 37.102S, 21.9072W' alt='Earthquake location 37.102S, 21.9072W' src='http://www.earthquakenewstoday.com/wp-content/uploads/35_20.jpg' width='146' height='146' />A minor earthquake with magnitude 3.5 (ml/mb) was detected on Tuesday, 8 kilometers (5 miles) from Aris in Greece.Exact location of event, depth 10 km, 21.9072&deg; East, 37.102&deg; North. </p>")
+                .content_type("text/html"))
             .updated(actual.updated));
 
     // Check
@@ -180,8 +181,8 @@ fn test_example_5() {
                 .category(Category::new("google"))
                 .id("https://arstechnica.com/?p=1546121")
                 .author(Person::new("Samuel Axon".into()))
-                .summary(Text::new("Alphabet has $117 billion in cash on hand.".into()))
-                .content(Content::default().body("Google co-founder Larry Page is now CEO of Alphabet."))
+                .summary(Text::html("Alphabet has $117 billion in cash on hand.".into()))
+                .content(Content::default().body("Google co-founder Larry Page is now CEO of Alphabet.").content_type("text/html"))
                 .updated(actual.updated),
         );
 
@@ -209,9 +210,10 @@ fn test_example_6() {
         .entry(Entry::default()
             .title(Text::new("Vitalina Varela - Trailer".into()))
             .link(Link::new("https://trailers.apple.com/trailers/independent/vitalina-varela", None))
-            .summary(Text::new("A film of deeply concentrated beauty, acclaimed filmmaker Pedro Costa’s VITALINA VARELA stars nonprofessional actor Vitalina Varela in an extraordinary performance based on her own life. Vitalina plays a Cape Verdean woman who has travelled to Lisbon to reunite with her husband, after two decades of separation, only to arrive mere days after his funeral. Alone in a strange forbidding land, she perseveres and begins to establish a new life. Winner of the Golden Leopard for Best Film and Best Actress at the Locarno Film Festival, as well as an official selection of the Sundance Film Festival, VITALINA VARELA is a film of shadow and whisper, a profoundly moving and visually ravishing masterpiece.".into()))
+            .summary(Text::html("A film of deeply concentrated beauty, acclaimed filmmaker Pedro Costa’s VITALINA VARELA stars nonprofessional actor Vitalina Varela in an extraordinary performance based on her own life. Vitalina plays a Cape Verdean woman who has travelled to Lisbon to reunite with her husband, after two decades of separation, only to arrive mere days after his funeral. Alone in a strange forbidding land, she perseveres and begins to establish a new life. Winner of the Golden Leopard for Best Film and Best Actress at the Locarno Film Festival, as well as an official selection of the Sundance Film Festival, VITALINA VARELA is a film of shadow and whisper, a profoundly moving and visually ravishing masterpiece.".into()))
             .content(Content::default()
-                .body(r#"<span style="font-size: 16px; font-weight: 900; text-decoration: underline;">Vitalina Varela - Trailer</span>"#))
+                .body(r#"<span style="font-size: 16px; font-weight: 900; text-decoration: underline;">Vitalina Varela - Trailer</span>"#)
+                .content_type("text/html"))
             .published_rfc3339("2020-02-06T08:00:00Z")
             .id("73226f21f249d758bd97a1fac90897d2")        // hash of the link
             .updated(actual.updated));
@@ -243,7 +245,7 @@ fn test_spec_1() {
         .ttl(40)
         .entry(
             Entry::default()
-                .summary(Text::new(
+                .summary(Text::html(
                     r#"Joshua Allen: <a href="http://www.netcrucible.com/blog/2002/09/29.html#a243">Who
                 loves namespaces?</a>
             "#
@@ -255,7 +257,7 @@ fn test_spec_1() {
         ) // copy from feed
         .entry(
             Entry::default()
-                .summary(Text::new(
+                .summary(Text::html(
                     r#"<a href="http://www.docuverse.com/blog/donpark/2002/09/29.html#a68">Don Park</a>:
                 "It is too easy for engineer to anticipate too much and XML Namespace is a frequent host of
                 over-anticipation."
@@ -295,6 +297,7 @@ fn test_heated() {
     let feed = parser::parse(test_data.as_slice()).unwrap();
     let content = &feed.entries[0].content.as_ref().unwrap();
     assert!(content.body.as_ref().unwrap().contains("I have some good news and some bad news"));
+    assert_eq!(content.content_type, "text/html");
 }
 
 // Check reported issue that RockPaperShotgun does not extract summary
@@ -336,8 +339,8 @@ fn test_spiegel() {
         .entry(
             Entry::default()
                 .title(Text::new("07.02. – die Wochenvorschau: Lockdown-Verlängerung, Kriegsverbrecher vor Gericht, Super Bowl, Karneval ".into()))
-                .content(Content::default().body(r#"Die wichtigsten Nachrichten aus der SPIEGEL-Redaktion. <br><br><p>See <a href="https://omnystudio.com/listener">omnystudio.com/listener</a> for privacy information.</p>"#))
-                .summary(Text::new("Die wichtigsten Nachrichten aus der SPIEGEL-Redaktion. \r\nSee omnystudio.com/listener for privacy information.".into()))
+                .content(Content::default().body(r#"Die wichtigsten Nachrichten aus der SPIEGEL-Redaktion. <br><br><p>See <a href="https://omnystudio.com/listener">omnystudio.com/listener</a> for privacy information.</p>"#).content_type("text/html"))
+                .summary(Text::html("Die wichtigsten Nachrichten aus der SPIEGEL-Redaktion. \r\nSee omnystudio.com/listener for privacy information.".into()))
                 .link(Link::new("https://omny.fm/shows/spiegel-update-die-nachrichten/07-02-die-wochenvorschau-lockdown-verl-ngerung-kri", None))
                 .published_rfc3339("2021-02-06T23:01:00Z")
                 .id("c7e3cca2-665e-4bc4-bcac-acc6011b9fa2")
@@ -406,7 +409,7 @@ fn test_bbc() {
         .entry(
             Entry::default()
                 .title(Text::new("Marcus Aurelius".into()))
-                .summary(Text::new("Melvyn Bragg and guests discuss...".into()))
+                .summary(Text::html("Melvyn Bragg and guests discuss...".into()))
                 .published_rfc2822("Thu, 25 Feb 2021 10:15:00 +0000")
                 .id("urn:bbc:podcast:m000sjxt")
                 .link(Link::new("http://www.bbc.co.uk/programmes/m000sjxt", None))
@@ -472,7 +475,7 @@ fn test_ch9() {
         .entry(
             Entry::default()
                 .title(Text::new("Troubleshoot AKS cluster issues with AKS Diagnostics and AKS Periscope".into()))
-                .summary(Text::new("<p>Yun Jung Choi shows Scott Hanselman...".into()))
+                .summary(Text::html("<p>Yun Jung Choi shows Scott Hanselman...".into()))
                 .link(Link::new(
                     "https://channel9.msdn.com/Shows/Azure-Friday/Troubleshoot-AKS-cluster-issues-with-AKS-Diagnostics-and-AKS-Periscope",
                     None,

--- a/feed-rs/src/parser/util.rs
+++ b/feed-rs/src/parser/util.rs
@@ -48,7 +48,7 @@ lazy_static! {
 
 /// Handles <content:encoded>
 pub(crate) fn handle_encoded<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Text>> {
-    Ok(element.children_as_string()?.map(Text::new))
+    Ok(element.children_as_string()?.map(Text::html))
 }
 
 /// Simplifies the "if let ... = parse ... assign" block


### PR DESCRIPTION
`<content:encoded>` is almost always HTML and this matches the [specification in the RSS 1 content module](https://web.resource.org/rss/1.0/modules/content/#syntax2).

`<description>` is also allowed by [the RSS2 specification](https://validator.w3.org/feed/docs/rss2.html#hrelementsOfLtitemgt) to be HTML. It appears that some feeds do not use HTML but include non-HTML-like formatting such as significant whitespace. I have not been able to find a feed where `<description>` has HTML special characters but not HTML so have not been able to confirm if any feeds are handled incorrectly by this. In order to make users aware of the commonly-used significant whitespace formatting a not has been added to the documentation of the `summary` field.

Both of these updates are validated by the existing tests in this repo where many were HTML and now have the correct content type while other tests were both valid HTML and plan text so have not been made worse by this change.

Fixes https://github.com/feed-rs/feed-rs/issues/129