### PR TITLE
Revert "Mark public `Self` returns with must_use."

### DIFF
--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -889,7 +889,6 @@ impl MediaRating {
         MediaRating { urn: "simple".into(), value }
     }
 
-    #[must_use]
     pub fn urn(mut self, urn: &str) -> Self {
         self.urn = urn.to_string();
         self
@@ -957,7 +956,6 @@ impl Person {
         }
     }
 
-    #[must_use]
     pub fn email(mut self, email: &str) -> Self {
         self.email = Some(email.to_owned());
         self

--- a/feed-rs/src/parser/rss2/mod.rs
+++ b/feed-rs/src/parser/rss2/mod.rs
@@ -179,10 +179,7 @@ fn handle_image<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Image
 
 // Handles <content:encoded>
 fn handle_content_encoded<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Content>> {
-    let src = element
-        .xml_base
-        .as_ref()
-        .map(|xml_base| Link::new(xml_base, element.xml_base.as_ref()));
+    let src = element.xml_base.as_ref().map(|xml_base| Link::new(xml_base, element.xml_base.as_ref()));
 
     Ok(element.children_as_string()?.map(|string| Content {
         body: Some(string),


### PR DESCRIPTION
Considered dropping the return of Self given the pending minor version
bump, but latest nightly (as of 2022/02/10) does not raise this error.

This reverts commit 5f38edbb0ef6f0a05621f9a5c5c513dd1c1012e6.