### PR TITLE
Upgrade to quick-xml 0.25

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -25,7 +25,7 @@ travis-ci = { repository = "feed-rs/feed-rs", branch = "master" }
 chrono = { version = "0.4" }
 lazy_static = "1.4"
 mime = "0.3"
-quick-xml = { version = "0.23", features = ["encoding"] }
+quick-xml = { version = "0.25", features = ["encoding"] }
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/feed-rs/src/xml/mod.rs
+++ b/feed-rs/src/xml/mod.rs
@@ -515,10 +515,16 @@ impl XmlEvent {
             .attributes()
             .filter_map(|a| {
                 if let Ok(a) = a {
-                    let name = reader.decoder().decode(a.key.as_ref()).unwrap();
+                    let name = match reader.decoder().decode(a.key.as_ref()) {
+                        Ok(decoded) => decoded,
+                        Err(_) => return None,
+                    };
 
                     // Unescape the XML attribute, or use the original value if this fails (broken escape sequence etc)
-                    let decoded_value = reader.decoder().decode(&a.value).unwrap();
+                    let decoded_value = match reader.decoder().decode(&a.value) {
+                        Ok(decoded) => decoded,
+                        Err(_) => return None,
+                    };
                     let value = escape::unescape(&decoded_value).unwrap_or_else(|_| decoded_value.to_owned()).to_string();
 
                     Some(NameValue { name: name.into(), value })

--- a/feed-rs/src/xml/mod.rs
+++ b/feed-rs/src/xml/mod.rs
@@ -297,10 +297,11 @@ impl<R: BufRead> SourceState<R> {
 
                 // CData is converted to text
                 Event::CData(t) => {
-                    let escaped = t.escape()?;
-                    let event = XmlEvent::text(&escaped, reader);
-                    if let Ok(Some(ref _t)) = event {
-                        return event;
+                    if let Ok(escaped) = t.escape() {
+                        let event = XmlEvent::text(&escaped, reader);
+                        if let Ok(Some(ref _t)) = event {
+                            return event;
+                        }
                     }
                 }
 


### PR DESCRIPTION
While working on the same side-project as https://github.com/feed-rs/feed-rs/pull/151, I also ran into an issue where some seemingly-valid feeds would fail to parse.
 
For example, `https://blog.pnkfx.org/atom.xml` results in:

```
0: unable to parse XML: Parser error: Expecting </content> found </title>    
1: Parser error: Expecting </content> found </title>
```

I believe this is related to a [recently-fixed issue in `quick-xml`](https://github.com/tafia/quick-xml/pull/471) so decided to upgrade the version used by `feed-rs`, which has fixed my issue.