### PR TITLE
Drop empty enclosures

### DIFF
--- a/feed-rs/fixture/rss_2.0_matrix.xml
+++ b/feed-rs/fixture/rss_2.0_matrix.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+        <title><![CDATA[matrix.org]]></title>
+        <description><![CDATA[Blog for the Matrix project]]></description>
+        <link>https://matrix.org</link>
+        <generator>GatsbyJS</generator>
+        <lastBuildDate>Tue, 27 Sep 2022 07:57:22 GMT</lastBuildDate>
+        <item>
+            <title><![CDATA[This Week in Matrix 2022-09-23]]></title>
+            <description>
+                <![CDATA[Matrix Live Dept of Social Good 🙆 carla  says Carla Griggio, a researcher at the University of Aarhus , is conducting Human-Computer…]]></description>
+            <link>https://matrix.org/blog/2022/09/23/this-week-in-matrix-2022-09-23</link>
+            <guid isPermaLink="false">https://matrix.org/blog/2022/09/23/this-week-in-matrix-2022-09-23</guid>
+            <pubDate>Fri, 23 Sep 2022 00:00:00 GMT</pubDate>
+            <content:encoded/>
+        </item>
+    </channel>
+</rss>

--- a/feed-rs/src/parser/rss2/mod.rs
+++ b/feed-rs/src/parser/rss2/mod.rs
@@ -181,11 +181,17 @@ fn handle_image<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Image
 fn handle_content_encoded<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Content>> {
     let src = element.xml_base.as_ref().map(|xml_base| Link::new(xml_base, element.xml_base.as_ref()));
 
-    Ok(element.children_as_string()?.map(|string| Content {
-        body: Some(string),
-        content_type: mime::TEXT_HTML,
-        src,
-        ..Default::default()
+    Ok(element.children_as_string()?.and_then(|string| {
+        if string.is_empty() {
+            None
+        } else {
+            Some(Content {
+                body: Some(string),
+                content_type: mime::TEXT_HTML,
+                src,
+                ..Default::default()
+            })
+        }
     }))
 }
 

--- a/feed-rs/src/parser/rss2/tests.rs
+++ b/feed-rs/src/parser/rss2/tests.rs
@@ -691,3 +691,14 @@ fn test_ghost_feeds() {
         }
     }
 }
+
+// Verifies that content is not set (as there is no enclosure in this case)
+#[test]
+fn test_matrix() {
+    let test_data = test::fixture_as_string("rss_2.0_matrix.xml");
+    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    let entry = actual.entries.get(0).expect("feed has 1 entry");
+
+    // The content should not be present
+    assert!(entry.content.is_none());
+}


### PR DESCRIPTION
The Matrix blog includes '<content:encoded/>' which was parsed as an empty string. The parser will now just return None in this case.

Fixes #155 