### PR TITLE
Upgrade to chrono 0.4.1, disable default features

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 travis-ci = { repository = "feed-rs/feed-rs", branch = "master" }
 
 [dependencies]
-chrono = { version = "0.4" }
+chrono = { version = "0.4.1", default-features = false }
 lazy_static = "1.4"
 mime = "0.3"
 quick-xml = { version = "0.25", features = ["encoding"] }


### PR DESCRIPTION
Disable default features from chrono (not used by feed-rs) to allow users of feed-rs to bring their own version of chrono, including 0.4.20+ (preferably 0.4.22) which avoids the [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159) vulnerability in the time crate.

The bump to chrono 0.4.1 is required in order to get the fix in chronotope/chrono#186 required by the `parser::util::tests::test_timestamp_rss2` test.