### PR TITLE
When possible, return full URLs for images in Atom feeds

### DIFF
--- a/feed-rs/fixture/atom_relative.xml
+++ b/feed-rs/fixture/atom_relative.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Example Feed with Relative URLs</title>
+  <link href="/blog/" />
+  <link rel="self" href="https://example.com/blog/feed.xml" />
+  <updated>2003-12-13T18:30:02Z</updated>
+  <logo>feed_logo.jpg</logo>
+  <icon>/favicon.ico</icon>
+  <author>
+    <name>Jane Doe</name>
+  </author>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+  <entry>
+    <title>Atom-Powered Robots Run Amok</title>
+    <link href="/blog/2003/12/13/atom03" />
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+    <summary>Some text.</summary>
+  </entry>
+</feed>

--- a/feed-rs/src/parser/atom/tests.rs
+++ b/feed-rs/src/parser/atom/tests.rs
@@ -376,6 +376,33 @@ fn test_spec_1() {
     assert_eq!(actual, expected);
 }
 
+#[test]
+fn test_relative_example() {
+    let test_data = test::fixture_as_string("atom_relative.xml");
+    let feed = parser::parse_with_uri(test_data.as_bytes(), Some("https://example.com/blog/feed.xml")).unwrap();
+
+    let feed_alternate_link = feed
+        .links
+        .iter()
+        .find(|l| l.rel.as_deref() == Some("alternate"))
+        .expect("feed has an alternate link");
+    assert_eq!("https://example.com/blog/", feed_alternate_link.href);
+
+    let icon = feed.icon.expect("feed has an icon");
+    assert_eq!("https://example.com/favicon.ico", icon.uri);
+
+    let logo = feed.logo.expect("feed has a logo");
+    assert_eq!("https://example.com/blog/feed_logo.jpg", logo.uri);
+
+    let entry = feed.entries.first().expect("feed has one entry");
+    let alternate_link = entry
+        .links
+        .iter()
+        .find(|l| l.rel.as_deref() == Some("alternate"))
+        .expect("entry has an alternate link");
+    assert_eq!("https://example.com/blog/2003/12/13/atom03", alternate_link.href);
+}
+
 // Verify we can parse Atom content elements without a type attribute
 // https://tools.ietf.org/html/rfc5023#section-9.2.1
 #[test]


### PR DESCRIPTION
URLs in Atom feeds are allowed to be relative. When using `feed_rs::parser::parse_with_uri`, relative URLs are resolved correctly using `element.xml_base`

https://github.com/feed-rs/feed-rs/blob/138bbf83bead06e4eb4fb8a84cd4fa1c72056c29/feed-rs/src/parser/atom/mod.rs#L224-L225

https://github.com/feed-rs/feed-rs/blob/138bbf83bead06e4eb4fb8a84cd4fa1c72056c29/feed-rs/src/model.rs#L633-L637

however images don't get the same treatment

https://github.com/feed-rs/feed-rs/blob/138bbf83bead06e4eb4fb8a84cd4fa1c72056c29/feed-rs/src/parser/atom/mod.rs#L217-L219

which is a bit inconvenient as knowledge of the base URL needs to be threaded through to wherever these relative URLs are used.

To remedy this I've added a failing test and modified `handle_image` to first attempt to parse the URL with the base and fallback to the raw value. This should be a non-breaking change as downstream consumers will have had to handle both relative and full URLs for these fields anyway.

----

Fun story - the feed that surfaced this discrepancy was `https://www.tbray.org/ongoing/ongoing.atom` and I wasn't about to question Tim Bray's XML 😂.