### PR TITLE
fix: add rfc3339 fix regex to append time

### DIFF
--- a/feed-rs/fixture/rss_1.0_debian.xml
+++ b/feed-rs/fixture/rss_1.0_debian.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="../../english/security/dsa-rdf.css" type="text/css"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns="http://purl.org/rss/1.0/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xml:lang="en"
+>
+<channel rdf:about="https://www.debian.org/News/news.rdf">
+  <title>Debian News</title>
+  <link>https://www.debian.org/News/</link>
+  <description>
+Debian Latest News
+  </description>
+  <dc:date>2022-12-20T23:28:24+00:00</dc:date>
+  <items>
+    <rdf:Seq>
+<rdf:li resource="https://www.debian.org/News/2022/20221217" />
+<rdf:li resource="https://www.debian.org/News/2022/2022091002" />
+<rdf:li resource="https://www.debian.org/News/2022/20220910" />
+<rdf:li resource="https://www.debian.org/News/2022/20220807" />
+<rdf:li resource="https://www.debian.org/News/2022/20220724" />
+<rdf:li resource="https://www.debian.org/News/2022/20220709" />
+    </rdf:Seq>
+  </items>
+</channel>
+<item rdf:about="https://www.debian.org/News/2022/20221217">
+  <title>Updated Debian 11: 11.6 released</title>
+  <link>https://www.debian.org/News/2022/20221217</link>
+  <description>
+    The Debian project is pleased to announce the sixth update of its
+stable distribution Debian 11 (codename &lt;q&gt;bullseye&lt;/q&gt;).
+This point release mainly adds corrections for security issues,
+along with a few adjustments for serious problems. Security advisories
+have already been published separately and are referenced where available.
+  </description>
+  <dc:date>2022-12-17</dc:date>
+</item>
+</rdf:RDF>

--- a/feed-rs/src/parser/rss1/tests.rs
+++ b/feed-rs/src/parser/rss1/tests.rs
@@ -139,3 +139,13 @@ fn test_spec_2() {
     // Check
     assert_eq!(actual, expected);
 }
+
+// Verifies that publish date is set
+#[test]
+fn test_debian() {
+    let test_data = test::fixture_as_string("rss_1.0_debian.xml");
+    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    let entry = actual.entries.get(0).expect("feed has 1 entry");
+
+    assert!(entry.published.is_some());
+}

--- a/feed-rs/src/parser/util.rs
+++ b/feed-rs/src/parser/util.rs
@@ -52,6 +52,8 @@ lazy_static! {
         vec!(
             // inserts missing colon in timezone
             (Regex::new(r#"(\+|-)(\d{2})(\d{2})"#).unwrap(), "${1}${2}:${3}"),
+            // appends time (midnight) and timezone (utc) if missing
+            (Regex::new(r"-\d{2}$").unwrap(), "${0}T00:00:00+00:00")
         )
     };
 }


### PR DESCRIPTION
I reported on this a while back, finally debugged the problem, though. Didn't realize DublinCore properties were already being handled in the library. (Deleted my comments in the issue as off-topic.)

The problem was just that the date in the RSS feed was in the format `yyyy-mm-dd`, which doesn't conform to RFC3339.

There are 2 approaches I can see here:
1. Attempt to parse it as `NaiveDate` and then transform it into `DateTime` one way or another.
2. Just add a regex to append midnight UTC if the time part isn't there.

I've opted for approach 2 in this PR.

## Related
* Closes https://github.com/feed-rs/feed-rs/issues/173

---

Note: Literally learned Rust just for this PR, don't be afraid to call out anything dumb and I'll change things up. :+1: 