### PR TITLE
Fix decoding regression

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -25,7 +25,7 @@ travis-ci = { repository = "feed-rs/feed-rs", branch = "master" }
 chrono = { version = "0.4.23", default-features = false }
 lazy_static = "1.4"
 mime = "0.3"
-quick-xml = { version = "0.27.0", features = ["encoding"] }
+quick-xml = { version = "0.27.1", features = ["encoding"] }
 regex = "1.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/feed-rs/fixture/rss_1.0_iso8859.xml
+++ b/feed-rs/fixture/rss_1.0_iso8859.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml-stylesheet href="http://www.w3.org/2000/08/w3c-synd/style.css" type="text/css"?>
+<!-- generator="FeedCreator 1.6" -->
+<rdf:RDF
+    xmlns="http://purl.org/rss/1.0/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:trackback="http://madskills.com/public/xml/rss/module/trackback/"
+    xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+    xmlns:content="http://purl.org/rss/1.0/modules/content/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel rdf:about="https://rss.golem.de/rss.php?feed=RSS1.0">
+        <title>Golem.de</title>
+        <description>IT-News fuer Profis</description>
+        <link>https://www.golem.de/</link>
+        <atom:link rel="self" href="https://rss.golem.de/rss.php?feed=RSS1.0" />
+        <image rdf:resource="https://www.golem.de/staticrl/images/golem-rss.png" />
+        <dc:date>2023-01-25T21:21:01+01:00</dc:date>
+        <items>
+            <rdf:Seq>
+                <rdf:li rdf:resource="https://www.golem.de/news/digitalministerium-neue-glasfaserfoerderung-mit-schnellkasse-2301-171451.html"/>
+            </rdf:Seq>
+        </items>
+    </channel>
+    <image rdf:about="https://www.golem.de/staticrl/images/golem-rss.png">
+        <title>Golem.de</title>
+        <link>https://www.golem.de/</link>
+        <url>https://www.golem.de/staticrl/images/golem-rss.png</url>
+    </image>
+    <item rdf:about="https://www.golem.de/news/digitalministerium-neue-glasfaserfoerderung-mit-schnellkasse-2301-171451.html">
+        <dc:format>text/html</dc:format>
+        <dc:date>2023-01-25T19:03:02+01:00</dc:date>
+        <dc:source>https://www.golem.de</dc:source>
+        <dc:creator>Achim Sawall</dc:creator>
+        <title>Digitalministerium: Neue Glasfaserförderung mit Schnellkasse</title>
+        <link>https://www.golem.de/news/digitalministerium-neue-glasfaserfoerderung-mit-schnellkasse-2301-171451.html</link>
+        <description>Ab April soll es wieder Förderung für den Ausbau von Glasfaser geben. Das Bundesdigitalministerium will es diesmal besser machen. (&lt;a href=&quot;https://www.golem.de/specials/infrastruktur/&quot;&gt;Infrastruktur&lt;/a&gt;, &lt;a href=&quot;https://www.golem.de/specials/glasfaser/&quot;&gt;Glasfaser&lt;/a&gt;) &lt;img src=&quot;https://cpx.golem.de/cpx.php?class=17&amp;amp;aid=171451&amp;amp;page=1&amp;amp;ts=1674669782&quot; alt=&quot;&quot; width=&quot;1&quot; height=&quot;1&quot; /&gt;</description>
+        <slash:comments />
+        <content:encoded><![CDATA[<img src="https://www.golem.de/2301/171451-364223-364219_rc.jpg" width="140" height="140" vspace="3" hspace="8" align="left">Ab April soll es wieder Förderung für den Ausbau von Glasfaser geben. Das Bundesdigitalministerium will es diesmal besser machen. (<a href="https://www.golem.de/specials/infrastruktur/">Infrastruktur</a>, <a href="https://www.golem.de/specials/glasfaser/">Glasfaser</a>) <img src="https://cpx.golem.de/cpx.php?class=17&amp;aid=171451&amp;page=1&amp;ts=1674669782" alt="" width="1" height="1" />]]></content:encoded>
+    </item>
+</rdf:RDF>

--- a/feed-rs/fixture/xml_iso8859.xml
+++ b/feed-rs/fixture/xml_iso8859.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<rdf>
+    <item>
+        <title>Digitalministerium: Neue Glasfaserförderung mit Schnellkasse</title>
+        <description>Ab April soll es wieder Förderung für den Ausbau von Glasfaser geben.</description>
+        <cdata><![CDATA[Ab April soll es wieder Förderung für den Ausbau von Glasfaser geben.]]></cdata>
+        <cdatanested><![CDATA[<p>Ab April soll es wieder Förderung für den Ausbau von Glasfaser geben.</p>]]></cdatanested>
+    </item>
+</rdf>

--- a/feed-rs/src/parser/rss1/tests.rs
+++ b/feed-rs/src/parser/rss1/tests.rs
@@ -149,3 +149,17 @@ fn test_debian() {
 
     assert!(entry.published.is_some());
 }
+
+// Verifies ISO8859 decoding works correctly
+#[test]
+fn test_iso8859() {
+    let test_data = test::fixture_as_raw("rss_1.0_iso8859.xml");
+    let actual = parser::parse(test_data.as_slice()).unwrap();
+    let entry = actual.entries.get(0).expect("feed has 1 entry");
+
+    let expected = "Ab April soll es wieder Förderung für den Ausbau von Glasfaser geben.";
+    let summary = &entry.summary.as_ref().unwrap().content;
+    assert!(summary.starts_with(expected));
+    let content = entry.content.as_ref().unwrap().body.as_ref().unwrap();
+    assert!(content.contains(expected));
+}

--- a/feed-rs/src/xml/tests.rs
+++ b/feed-rs/src/xml/tests.rs
@@ -229,3 +229,31 @@ fn test_xml_unescape_attrib() -> TestResult {
 
     Ok(())
 }
+
+// Verifies decoding of ISO 8859 content works correctly
+#[test]
+fn test_iso8859_decode() -> TestResult {
+    let xml = test::fixture_as_raw("xml_iso8859.xml");
+    let source = ElementSource::new(xml.as_slice(), None)?;
+    let root = source.root()?.unwrap();
+    let item = root.children().next().unwrap()?;
+
+    let mut elements = item.children();
+
+    let title = elements.next().unwrap()?.child_as_text().unwrap();
+    assert_eq!(title, "Digitalministerium: Neue Glasfaserförderung mit Schnellkasse");
+
+    let expected = "Ab April soll es wieder Förderung für den Ausbau von Glasfaser geben.";
+
+    let description = elements.next().unwrap()?.child_as_text().unwrap();
+    assert_eq!(description, expected);
+
+    let cdata = elements.next().unwrap()?.child_as_text().unwrap();
+    assert_eq!(cdata, expected);
+
+    // The nested XML (or HTML in feeds) breaks the decoding
+    let nested = elements.next().unwrap()?.child_as_text().unwrap();
+    assert_eq!(nested, format!("<p>{}</p>", expected));
+
+    Ok(())
+}


### PR DESCRIPTION
Upgrade to quick-xml no longer requires encoding on cdata during
parsing. Added some sample files to validate fix too.

Fixes #172 