### PR TITLE
Trim whitespace

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -31,4 +31,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 siphasher = "0.3"
 url = "2.3"
-uuid = { version = "1.2", features = ["v4"] }
+uuid = { version = "1.3", features = ["v4"] }

--- a/feed-rs/fixture/rss_2.0_nightvale.xml
+++ b/feed-rs/fixture/rss_2.0_nightvale.xml
@@ -1,0 +1,69 @@
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:media="http://search.yahoo.com/mrss/" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+    <channel>
+        <title>Welcome to Night Vale</title>
+        <link>http://welcometonightvale.com</link>
+        <pubDate>Wed, 01 Feb 2023 05:00:00 -0000</pubDate>
+        <lastBuildDate>Thu, 02 Feb 2023 22:28:21 -0000</lastBuildDate>
+        <ttl>60</ttl>
+        <language>en</language>
+        <copyright>2016, Night Vale Presents</copyright>
+        <webMaster>help@prx.org (PRX)</webMaster>
+        <description>
+            <![CDATA[ <p>Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen.</p> ]]>
+        </description>
+        <managingEditor>info@welcometonightvale.com (info@welcometonightvale.com)</managingEditor>
+        <generator>PRX Feeder v1.0.0</generator>
+        <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+        <image>
+            <url>https://f.prxu.org/126/images/bc7d203a-c0dd-46ec-956b-03bad13ba85e/nightvalelogo-web4.jpg</url>
+            <title>Welcome to Night Vale</title>
+            <link>http://welcometonightvale.com</link>
+            <width>1400</width>
+            <height>1400</height>
+            <description>Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true.</description>
+        </image>
+        <atom:link href="https://f.prxu.org/126/feed-rss.xml" rel="self" type="application/rss+xml"/>
+        <itunes:author>Night Vale Presents</itunes:author>
+        <itunes:type>episodic</itunes:type>
+        <itunes:category text="Fiction">
+            <itunes:category text="Science Fiction"/>
+        </itunes:category>
+        <itunes:image href="https://f.prxu.org/126/images/1f749c5d-c83a-4db9-8112-a3245da49c54/nightvalelogo-web4.jpg"/>
+        <itunes:explicit>false</itunes:explicit>
+        <itunes:owner>
+            <itunes:email>info@welcometonightvale.com</itunes:email>
+            <itunes:name>Welcome to Night Vale</itunes:name>
+        </itunes:owner>
+        <itunes:subtitle>Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true.</itunes:subtitle>
+        <itunes:summary>
+            <![CDATA[ Twice-monthly community updates for the small desert town of Night Vale, where every conspiracy theory is true. Turn on your radio and hide. Never listened before? It's an ongoing radio show. Start with the current episode, and you'll catch on in no time. Or, go right to Episode 1 if you wanna binge-listen. ]]>
+        </itunes:summary>
+        <itunes:keywords>cecil,commonplace,cranor,fink,lovecraft,neofuturists,night,nightvale,nightvaleradio,radio,vale,welcome</itunes:keywords>
+        <media:copyright>2016, Night Vale Presents</media:copyright>
+        <media:thumbnail url="https://f.prxu.org/126/images/bc7d203a-c0dd-46ec-956b-03bad13ba85e/nightvalelogo-web4.jpg"/>
+        <media:keywords>cecil,commonplace,cranor,fink,lovecraft,neofuturists,night,nightvale,nightvaleradio,radio,vale,welcome</media:keywords>
+        <media:category scheme="http://www.itunes.com/dtds/podcast-1.0.dtd">Fiction</media:category>
+        <item>
+            <guid isPermaLink="false">prx_126_c6d43512-3eb0-41bc-9092-393412cae641</guid>
+            <title>221 - The Glow Cloud, Explained</title>
+            <pubDate>Wed, 01 Feb 2023 05:00:00 -0000</pubDate>
+            <link>https://beta.prx.org/stories/441886</link>
+            <description>
+                <![CDATA[ <p>The University of What It Is takes a special interest in a certain glowing cloud.</p> <p>Weather: “Blackeyeblue“ by <a href="https://shotgunmarmalade.bandcamp.com/" rel="nofollow" target="_blank">Shotgun Marmalade</a></p> <p>The voice of Dr. Janet Lubelle is Janet Varney.</p> <p>Original episode art by <a href="http://www.jessica-hayworth.com/" rel="nofollow" target="_blank">Jessica Hayworth</a></p> <p><a href="http://welcometonightvale.com/transcripts" rel="nofollow" target="_blank">Read episode transcripts</a></p> <p>Our new podcast, <a href="http://audible.com/unlicensed" rel="nofollow" target="_blank">UNLICENSED, available now! </a></p> <p><a href="http://welcometonightvale.com/live" rel="nofollow" target="_blank">2023 US TOUR DATES</a> for “The Haunting of Night Vale”</p> <p><a href="http://patreon.com/welcometonightvale/" rel="nofollow" target="_blank">Patreon is how we exist</a>! If you can, please help us keep making this show.</p> <p>Music: <a href="http://disparition.bandcamp.com" rel="nofollow" target="_blank">Disparition</a></p> <p>Logo: <a href="http://robwilsonwork.com" rel="nofollow" target="_blank">Rob Wilson</a></p> <p>Written by Joseph Fink &amp; Jeffrey Cranor</p> <p>Narrated by Cecil Baldwin</p> <p>Follow us on <a href="https://twitter.com/NightValeRadio" rel="nofollow" target="_blank">Twitter</a>, <a href="https://www.facebook.com/WelcomeToNightVale/" rel="nofollow" target="_blank">Facebook</a>, and <a href="https://www.instagram.com/nightvaleofficial/" rel="nofollow" target="_blank">Instagram</a>.</p> <p>Check out our books, live shows, store, membership program, and official recap show at <a href="https://welcometonightvale.com" rel="nofollow" target="_blank">welcometonightvale.com</a></p> <p>A production of <a href="http://nightvalepresents.com" rel="nofollow" target="_blank">Night Vale Presents</a>.</p> ]]>
+            </description>
+            <enclosure url="https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/c6d43512-3eb0-41bc-9092-393412cae641/nv221_intro.mp3" type="audio/mpeg" length="38749539"/>
+            <itunes:subtitle>The University of What It Is takes a special interest in a certain glowing cloud.</itunes:subtitle>
+            <itunes:episodeType>full</itunes:episodeType>
+            <itunes:duration>26:53</itunes:duration>
+            <itunes:author>Night Vale Presents</itunes:author>
+            <itunes:summary>
+                <![CDATA[ The University of What It Is takes a special interest in a certain glowing cloud. Weather: “Blackeyeblue“ by <a href="https://shotgunmarmalade.bandcamp.com/" target="_blank">Shotgun Marmalade</a> The voice of Dr. Janet Lubelle is Janet Varney. Original episode art by <a href="http://www.jessica-hayworth.com/" target="_blank">Jessica Hayworth</a> <a href="http://welcometonightvale.com/transcripts" target="_blank">Read episode transcripts</a> Our new podcast, <a href="http://audible.com/unlicensed" target="_blank">UNLICENSED, available now! </a> <a href="http://welcometonightvale.com/live" target="_blank">2023 US TOUR DATES</a> for “The Haunting of Night Vale” <a href="http://patreon.com/welcometonightvale/" target="_blank">Patreon is how we exist</a>! If you can, please help us keep making this show. Music: <a href="http://disparition.bandcamp.com" target="_blank">Disparition</a> Logo: <a href="http://robwilsonwork.com" target="_blank">Rob Wilson</a> Written by Joseph Fink &amp; Jeffrey Cranor Narrated by Cecil Baldwin Follow us on <a href="https://twitter.com/NightValeRadio" target="_blank">Twitter</a>, <a href="https://www.facebook.com/WelcomeToNightVale/" target="_blank">Facebook</a>, and <a href="https://www.instagram.com/nightvaleofficial/" target="_blank">Instagram</a>. Check out our books, live shows, store, membership program, and official recap show at <a href="https://welcometonightvale.com" target="_blank">welcometonightvale.com</a> A production of <a href="http://nightvalepresents.com" target="_blank">Night Vale Presents</a>. ]]>
+            </itunes:summary>
+            <itunes:image href="https://f.prxu.org/126/c6d43512-3eb0-41bc-9092-393412cae641/images/13851a89-c4ee-4f9d-b98b-00a238b94bdc/nightvalelogo_web4.jpg"/>
+            <media:content fileSize="38749539" type="audio/mpeg" url="https://www.podtrac.com/pts/redirect.mp3/dovetail.prxu.org/_/126/c6d43512-3eb0-41bc-9092-393412cae641/nv221_intro.mp3"/>
+            <content:encoded>
+                <![CDATA[ <p>The University of What It Is takes a special interest in a certain glowing cloud.</p> <p>Weather: “Blackeyeblue“ by <a href="https://shotgunmarmalade.bandcamp.com/" rel="nofollow" target="_blank">Shotgun Marmalade</a></p> <p>The voice of Dr. Janet Lubelle is Janet Varney.</p> <p>Original episode art by <a href="http://www.jessica-hayworth.com/" rel="nofollow" target="_blank">Jessica Hayworth</a></p> <p><a href="http://welcometonightvale.com/transcripts" rel="nofollow" target="_blank">Read episode transcripts</a></p> <p>Our new podcast, <a href="http://audible.com/unlicensed" rel="nofollow" target="_blank">UNLICENSED, available now! </a></p> <p><a href="http://welcometonightvale.com/live" rel="nofollow" target="_blank">2023 US TOUR DATES</a> for “The Haunting of Night Vale”</p> <p><a href="http://patreon.com/welcometonightvale/" rel="nofollow" target="_blank">Patreon is how we exist</a>! If you can, please help us keep making this show.</p> <p>Music: <a href="http://disparition.bandcamp.com" rel="nofollow" target="_blank">Disparition</a></p> <p>Logo: <a href="http://robwilsonwork.com" rel="nofollow" target="_blank">Rob Wilson</a></p> <p>Written by Joseph Fink &amp; Jeffrey Cranor</p> <p>Narrated by Cecil Baldwin</p> <p>Follow us on <a href="https://twitter.com/NightValeRadio" rel="nofollow" target="_blank">Twitter</a>, <a href="https://www.facebook.com/WelcomeToNightVale/" rel="nofollow" target="_blank">Facebook</a>, and <a href="https://www.instagram.com/nightvaleofficial/" rel="nofollow" target="_blank">Instagram</a>.</p> <p>Check out our books, live shows, store, membership program, and official recap show at <a href="https://welcometonightvale.com" rel="nofollow" target="_blank">welcometonightvale.com</a></p> <p>A production of <a href="http://nightvalepresents.com" rel="nofollow" target="_blank">Night Vale Presents</a>.</p> ]]>
+            </content:encoded>
+        </item>
+    </channel>
+</rss>

--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -353,7 +353,7 @@ impl Entry {
     }
 
     pub fn id(mut self, id: &str) -> Self {
-        self.id = id.to_string();
+        self.id = id.trim().to_string();
         self
     }
 
@@ -635,7 +635,9 @@ impl Link {
         let href = match util::parse_uri(href.as_ref(), base) {
             Some(uri) => uri.to_string(),
             None => href.as_ref().to_string(),
-        };
+        }
+        .trim()
+        .to_string();
 
         Link {
             href,
@@ -977,7 +979,7 @@ impl Text {
         Text {
             content_type: mime::TEXT_PLAIN,
             src: None,
-            content,
+            content: content.trim().to_string(),
         }
     }
 
@@ -985,7 +987,7 @@ impl Text {
         Text {
             content_type: mime::TEXT_HTML,
             src: None,
-            content,
+            content: content.trim().to_string(),
         }
     }
 }

--- a/feed-rs/src/parser/atom/tests.rs
+++ b/feed-rs/src/parser/atom/tests.rs
@@ -14,41 +14,33 @@ fn test_example_1() {
     // Expected feed
     let expected = Feed::new(FeedType::Atom)
         .title(Text::new("dive into mark".into()))
-        .description(Text::new("\n        A <em>lot</em> of effort\n        went into making this effortless\n    ".into())
-            .content_type("text/html"))
+        .description(Text::new("A <em>lot</em> of effort\n        went into making this effortless".into()).content_type("text/html"))
         .updated_rfc3339("2005-07-31T12:29:29Z")
         .id("tag:example.org,2003:3")
-        .link(Link::new("http://example.org/", None)
-            .rel("alternate")
-            .media_type("text/html")
-            .href_lang("en"))
-        .link(Link::new("http://example.org/feed.atom", None)
-            .rel("self")
-            .media_type("application/atom+xml"))
+        .link(Link::new("http://example.org/", None).rel("alternate").media_type("text/html").href_lang("en"))
+        .link(Link::new("http://example.org/feed.atom", None).rel("self").media_type("application/atom+xml"))
         .rights(Text::new("Copyright (c) 2003, Mark Pilgrim".into()))
-        .generator(Generator::new("Example Toolkit")
-            .uri("http://www.example.com/")
-            .version("1.0"))
-        .entry(Entry::default()
-            .id("tag:example.org,2003:3.2397")
-            .title(Text::new("Atom draft-07 snapshot".into()))
-            .updated_rfc3339("2005-07-31T12:29:29Z")
-            .author(Person::new("Mark Pilgrim")
-                .uri("http://example.org/")
-                .email("f8dy@example.com"))
-            .link(Link::new("http://example.org/2005/04/02/atom", None)
-                .rel("alternate")
-                .media_type("text/html"))
-            .link(Link::new("http://example.org/audio/ph34r_my_podcast.mp3", None)
-                .rel("enclosure")
-                .media_type("audio/mpeg")
-                .length(1337))
-            .contributor(Person::new("Sam Ruby"))
-            .contributor(Person::new("Joe Gregorio"))
-            .content(Content::default()
-                .content_type("text/html")
-                .body("\n            <div>\n                <p>\n                    <i>[Update: The Atom draft is finished.]</i>\n                </p>\n            </div>\n        "))
-            .published_rfc3339("2003-12-13T08:29:29-04:00"));
+        .generator(Generator::new("Example Toolkit").uri("http://www.example.com/").version("1.0"))
+        .entry(
+            Entry::default()
+                .id("tag:example.org,2003:3.2397")
+                .title(Text::new("Atom draft-07 snapshot".into()))
+                .updated_rfc3339("2005-07-31T12:29:29Z")
+                .author(Person::new("Mark Pilgrim").uri("http://example.org/").email("f8dy@example.com"))
+                .link(Link::new("http://example.org/2005/04/02/atom", None).rel("alternate").media_type("text/html"))
+                .link(
+                    Link::new("http://example.org/audio/ph34r_my_podcast.mp3", None)
+                        .rel("enclosure")
+                        .media_type("audio/mpeg")
+                        .length(1337),
+                )
+                .contributor(Person::new("Sam Ruby"))
+                .contributor(Person::new("Joe Gregorio"))
+                .content(Content::default().content_type("text/html").body(
+                    "<div>\n                <p>\n                    <i>[Update: The Atom draft is finished.]</i>\n                </p>\n            </div>",
+                ))
+                .published_rfc3339("2003-12-13T08:29:29-04:00"),
+        );
 
     // Check
     assert_eq!(actual, expected);
@@ -147,8 +139,7 @@ fn test_example_3() {
                 .label("Zero Trust")
                 .scheme("http://www.sixapart.com/ns/types#tag"))
             .content(Content::default()
-                .body(r#"
-        <p>We all heed the gospel of patching, but as recent incidents made clear, even cutting-edge disruptors struggle to patch everything, everywhere, and all the time.</p>
+                .body(r#"<p>We all heed the gospel of patching, but as recent incidents made clear, even cutting-edge disruptors struggle to patch everything, everywhere, and all the time.</p>
         <img src="http://feeds.feedburner.com/~r/TheAkamaiBlog/~4/NnQEuqRSyug" height="1" width="1" alt=""/>"#)
                 .content_type("text/html")));
 
@@ -264,8 +255,7 @@ fn test_example_6() {
             <li>Switch to event-based parser (xml-rs) to reduce peak memory usage and use of clone()</li>
             <li>Expanded test coverage</li>
             <li>Documentation improvements</li>
-            </ul>
-        "#,
+            </ul>"#,
                         )
                         .content_type("text/html"),
                 )
@@ -322,8 +312,7 @@ fn test_example_6() {
 // Verify that we don't trim essential whitespace
 #[test]
 fn test_example_7() {
-    let expected_body = r#"<div xmlns="http://www.w3.org/1999/xhtml"><p>This is a follow up from <a href="https://who-t.blogspot.com/2018/12/high-resolution-wheel-scrolling-on.html">the kernel support for high-resolution wheel scrolling</a> which you totally forgot about because it's already more then a year in the past and seriously, who has the attention span these days to remember this. Anyway, I finally found time and motivation to pick this up again and I started lining up the pieces like cans, for it only to be shot down by the commentary of strangers on the internet. The <a href="https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/72">Wayland merge request</a> lists the various pieces (libinput, wayland, weston, mutter, gtk and Xwayland) but for the impatient there's also an <a href="https://copr.fedorainfracloud.org/coprs/whot/high-resolution-wheel-scrolling/">Fedora 32 COPR</a>. For all you weirdos inexplicably not running the latest Fedora, well, you'll have to compile this yourself, just like I did. </p> <p>Let's recap: in v5.0 the kernel added new axes <b>REL_WHEEL_HI_RES</b> and <b>REL_HWHEEL_HI_RES</b> for all devices. On devices that actually support high-resolution wheel scrolling (Logitech and Microsoft mice, primarily) you'll get multiple hires events before the now-legacy <b>REL_WHEEL</b> events. On all other devices those two are in sync. </p> <p>Integrating this into the userspace stack was a bit of a mess at first, but I think the solution is good enough, even if it has a rather verbose explanation on how to handle it. The actual patches to integrate ended up being relatively simple. So let's see why it's a bit weird: </p> <p>When Wayland started, back in WhoahReallyThatLongAgo, scrolling was specified as the <b>wl_pointer.axis</b> event with a value in pixels. This works fine for touchpads, not so much for wheels. The early versions of Weston decreed that one wheel click was 10 pixels [1] and, perhaps surprisingly, the world kept on turning. When libinput was forked from Weston <a href="https://who-t.blogspot.com/2015/01/providing-physical-movement-of-wheel.html">an early change</a> was that wheel events would have two values - degrees of movement and click count ("discrete steps"). The wayland protocol was expanded to include the discrete steps as <b>wl_pointer.axis_discrete</b> as well. Then backwards compatibility reared its ugly head and Mutter, Weston, GTK all basically said: one discrete step equals 10 pixels so we multiply the discrete value by 10 and, perhaps surprisingly, the world kept on turning. </p> <p>This worked out well enough for a few years but with high resolution wheels we ran into a problem. Discrete steps are integers, so we can't send partial values. And the protocol is defined in a way that any tweaking of the behaviour would result in broken clients which, perhaps surprisingly, is a Bad Thing. This lead to the current proposal of separate events. <b>LIBINPUT_EVENT_POINTER_AXIS_WHEEL</b> and for Wayland the <b>wl_pointer.axis_v120</b> event, linked to above. These events are (like the kernel events) a parallel event stream to the previous events and effectively replace the <b>LIBINPUT_EVENT_POINTER_AXIS</b> and Wayland <b>wl_pointer.axis/axis_discrete</b> pair for wheel events (not so for touchpad or button scrolling though). </p> <p>The compositor side of things is relatively simple: take the events from libinput and pass the hires ones as v120 events and the lowres ones as v120 events with a value of zero. The client side takes the v120 events and uses them over <b>wl_pointer.axis/axis_discrete</b> unless one is zero in which case you can discard all axis events in that <b>wl_pointer.frame</b>. Since most client implementation already have the support for smooth scrolling (because, well, touchpads do exist) it's relatively simple to integrate - the new events just feed into the smooth scrolling code. And since you already have to do wheel emulation for that (because, well, old clients exist) wheel emulation is handled easily too. </p> <p>All that to provide buttery smooth [2] wheel scrolling. Or not, if your hardware doesn't support it. In which case, well, live with the warm fuzzy feeling that someone else has a better user experience now. Or soon, anyway. </p> <p><small>[1] with, I suspect, the scientific measurement of "yeah, that seems about alright"<br></br>[2] like butter out of a fridge, so still chunky but at least less so than before<br></br></small></p></div>
-    "#;
+    let expected_body = r#"<div xmlns="http://www.w3.org/1999/xhtml"><p>This is a follow up from <a href="https://who-t.blogspot.com/2018/12/high-resolution-wheel-scrolling-on.html">the kernel support for high-resolution wheel scrolling</a> which you totally forgot about because it's already more then a year in the past and seriously, who has the attention span these days to remember this. Anyway, I finally found time and motivation to pick this up again and I started lining up the pieces like cans, for it only to be shot down by the commentary of strangers on the internet. The <a href="https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/72">Wayland merge request</a> lists the various pieces (libinput, wayland, weston, mutter, gtk and Xwayland) but for the impatient there's also an <a href="https://copr.fedorainfracloud.org/coprs/whot/high-resolution-wheel-scrolling/">Fedora 32 COPR</a>. For all you weirdos inexplicably not running the latest Fedora, well, you'll have to compile this yourself, just like I did. </p> <p>Let's recap: in v5.0 the kernel added new axes <b>REL_WHEEL_HI_RES</b> and <b>REL_HWHEEL_HI_RES</b> for all devices. On devices that actually support high-resolution wheel scrolling (Logitech and Microsoft mice, primarily) you'll get multiple hires events before the now-legacy <b>REL_WHEEL</b> events. On all other devices those two are in sync. </p> <p>Integrating this into the userspace stack was a bit of a mess at first, but I think the solution is good enough, even if it has a rather verbose explanation on how to handle it. The actual patches to integrate ended up being relatively simple. So let's see why it's a bit weird: </p> <p>When Wayland started, back in WhoahReallyThatLongAgo, scrolling was specified as the <b>wl_pointer.axis</b> event with a value in pixels. This works fine for touchpads, not so much for wheels. The early versions of Weston decreed that one wheel click was 10 pixels [1] and, perhaps surprisingly, the world kept on turning. When libinput was forked from Weston <a href="https://who-t.blogspot.com/2015/01/providing-physical-movement-of-wheel.html">an early change</a> was that wheel events would have two values - degrees of movement and click count ("discrete steps"). The wayland protocol was expanded to include the discrete steps as <b>wl_pointer.axis_discrete</b> as well. Then backwards compatibility reared its ugly head and Mutter, Weston, GTK all basically said: one discrete step equals 10 pixels so we multiply the discrete value by 10 and, perhaps surprisingly, the world kept on turning. </p> <p>This worked out well enough for a few years but with high resolution wheels we ran into a problem. Discrete steps are integers, so we can't send partial values. And the protocol is defined in a way that any tweaking of the behaviour would result in broken clients which, perhaps surprisingly, is a Bad Thing. This lead to the current proposal of separate events. <b>LIBINPUT_EVENT_POINTER_AXIS_WHEEL</b> and for Wayland the <b>wl_pointer.axis_v120</b> event, linked to above. These events are (like the kernel events) a parallel event stream to the previous events and effectively replace the <b>LIBINPUT_EVENT_POINTER_AXIS</b> and Wayland <b>wl_pointer.axis/axis_discrete</b> pair for wheel events (not so for touchpad or button scrolling though). </p> <p>The compositor side of things is relatively simple: take the events from libinput and pass the hires ones as v120 events and the lowres ones as v120 events with a value of zero. The client side takes the v120 events and uses them over <b>wl_pointer.axis/axis_discrete</b> unless one is zero in which case you can discard all axis events in that <b>wl_pointer.frame</b>. Since most client implementation already have the support for smooth scrolling (because, well, touchpads do exist) it's relatively simple to integrate - the new events just feed into the smooth scrolling code. And since you already have to do wheel emulation for that (because, well, old clients exist) wheel emulation is handled easily too. </p> <p>All that to provide buttery smooth [2] wheel scrolling. Or not, if your hardware doesn't support it. In which case, well, live with the warm fuzzy feeling that someone else has a better user experience now. Or soon, anyway. </p> <p><small>[1] with, I suspect, the scientific measurement of "yeah, that seems about alright"<br></br>[2] like butter out of a fridge, so still chunky but at least less so than before<br></br></small></p></div>"#;
     // Parse the feed
     let test_data = test::fixture_as_string("atom_example_7.xml");
     let feed = parser::parse(test_data.as_bytes()).unwrap();

--- a/feed-rs/src/parser/itunes.rs
+++ b/feed-rs/src/parser/itunes.rs
@@ -1,5 +1,5 @@
 use crate::model::{Category, Feed, Image, MediaCredit, MediaObject, MediaRating, MediaThumbnail, Person};
-use crate::parser::atom::handle_text;
+use crate::parser::atom;
 use crate::parser::util::{if_some_then, parse_npt};
 use crate::parser::ParseFeedResult;
 use crate::xml::{Element, NS};
@@ -38,7 +38,7 @@ pub(crate) fn handle_itunes_channel_element<R: BufRead>(element: Element<R>, fee
 // Process <itunes> elements at item level and turn them into something that looks like MediaRSS objects.
 pub(crate) fn handle_itunes_item_element<R: BufRead>(element: Element<R>, media_obj: &mut MediaObject) -> ParseFeedResult<()> {
     match element.ns_and_tag() {
-        (NS::Itunes, "title") => media_obj.title = handle_text(element)?,
+        (NS::Itunes, "title") => media_obj.title = atom::handle_text(element)?,
 
         (NS::Itunes, "image") => if_some_then(handle_image(element), |thumbnail| media_obj.thumbnails.push(thumbnail)),
 
@@ -46,7 +46,7 @@ pub(crate) fn handle_itunes_item_element<R: BufRead>(element: Element<R>, media_
 
         (NS::Itunes, "author") => if_some_then(handle_author(element), |credit| media_obj.credits.push(credit)),
 
-        (NS::Itunes, "summary") => media_obj.description = handle_text(element)?,
+        (NS::Itunes, "summary") => media_obj.description = atom::handle_text(element)?,
 
         // Nothing required for unknown elements
         _ => {}

--- a/feed-rs/src/parser/rss0/tests.rs
+++ b/feed-rs/src/parser/rss0/tests.rs
@@ -92,7 +92,7 @@ fn test_0_92_spec_1() {
         .id(actual.id.as_ref())     // not present in the test data
         .title(Text::new("Dave Winer: Grateful Dead".into()))
         .link(Link::new("http://www.scripting.com/blog/categories/gratefulDead.html", None))
-        .description(Text::new("A high-fidelity Grateful Dead song every day. This is where we're experimenting with\n            enclosures on RSS news items that download when you're not using your computer. If it works (it will)\n            it will be the end of the Click-And-Wait multimedia experience on the Internet.\n        ".into()))
+        .description(Text::new("A high-fidelity Grateful Dead song every day. This is where we're experimenting with\n            enclosures on RSS news items that download when you're not using your computer. If it works (it will)\n            it will be the end of the Click-And-Wait multimedia experience on the Internet.".into()))
         .updated_rfc2822("Fri, 13 Apr 2001 19:23:02 GMT")
         .contributor(Person::new("managingEditor").email("dave@userland.com (Dave Winer)"))
         .contributor(Person::new("webMaster").email("dave@userland.com (Dave Winer)"))

--- a/feed-rs/src/parser/rss1/tests.rs
+++ b/feed-rs/src/parser/rss1/tests.rs
@@ -78,7 +78,7 @@ fn test_spec_1() {
         .id(actual.id.as_ref())     // not present in the test data
         .title(Text::new("XML.com".into()))
         .link(Link::new("http://xml.com/pub", None))
-        .description(Text::new("\n            XML.com features a rich mix of information and services\n            for the XML community.\n        ".into()))
+        .description(Text::new("XML.com features a rich mix of information and services\n            for the XML community.".into()))
         .logo(Image::new("http://xml.com/universal/images/xml_tiny.gif".into())
             .link("http://www.xml.com")
             .title("XML.com"))
@@ -88,13 +88,13 @@ fn test_spec_1() {
             .updated(entry0.updated)            // not present in the test data
             .title(Text::new("Processing Inclusions with XSLT".into()))
             .link(Link::new("http://xml.com/pub/2000/08/09/xslt/xslt.html", None))
-            .summary(Text::new("\n\n            Processing document inclusions with general XML tools can be\n            problematic. This article proposes a way of preserving inclusion\n            information through SAX-based processing.\n        ".into())))
+            .summary(Text::new("Processing document inclusions with general XML tools can be\n            problematic. This article proposes a way of preserving inclusion\n            information through SAX-based processing.".into())))
         .entry(Entry::default()
             .id("54f62e9fe8901546d7e25c0827e1b8e8")     // hash of the link
             .updated(entry1.updated)            // not present in the test data
             .title(Text::new("Putting RDF to Work".into()))
             .link(Link::new("http://xml.com/pub/2000/08/09/rdfdb/index.html", None))
-            .summary(Text::new("\n            Tool and API support for the Resource Description Framework\n            is slowly coming of age. Edd Dumbill takes a look at RDFDB,\n            one of the most exciting new RDF toolkits.\n        ".into())));
+            .summary(Text::new("Tool and API support for the Resource Description Framework\n            is slowly coming of age. Edd Dumbill takes a look at RDFDB,\n            one of the most exciting new RDF toolkits.".into())));
 
     // Check
     assert_eq!(actual, expected);
@@ -129,8 +129,7 @@ fn test_spec_2() {
                 .title(Text::new("XML: A Disruptive Technology".into()))
                 .link(Link::new("http://c.moreover.com/click/here.pl?r123", None))
                 .summary(Text::new(
-                    "\n            XML is placing increasingly heavy loads on the existing technical\n            infrastructure of the Internet.\n        "
-                        .into(),
+                    "XML is placing increasingly heavy loads on the existing technical\n            infrastructure of the Internet.".into(),
                 ))
                 .author(Person::new("Simon St.Laurent (mailto:simonstl@simonstl.com)"))
                 .rights(Text::new("Copyright © 2000 O'Reilly & Associates, Inc.".into())),

--- a/feed-rs/src/parser/rss2/mod.rs
+++ b/feed-rs/src/parser/rss2/mod.rs
@@ -226,7 +226,7 @@ fn handle_item<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Entry>
 
             (NS::RSS, "category") => if_some_then(handle_category(child), |category| entry.categories.push(category)),
 
-            (NS::RSS, "guid") => if_some_then(child.child_as_text(), |guid| entry.id = guid),
+            (NS::RSS, "guid") => if_some_then(child.child_as_text(), |guid| entry.id = guid.trim().to_string()),
 
             (NS::RSS, "enclosure") => handle_enclosure(child, &mut media_obj),
 
@@ -265,7 +265,11 @@ fn handle_link<R: BufRead>(element: Element<R>) -> Option<Link> {
 
 // Handles <title>, <description> etc
 fn handle_text<R: BufRead>(element: Element<R>) -> Option<Text> {
-    element.child_as_text().map(Text::new)
+    if let Ok(Some(text)) = element.children_as_string() {
+        Some(Text::new(text))
+    } else {
+        None
+    }
 }
 
 // Handles date/time

--- a/feed-rs/src/parser/rss2/tests.rs
+++ b/feed-rs/src/parser/rss2/tests.rs
@@ -59,12 +59,12 @@ fn test_example_2() {
             .email("brian.dunbar@nasa.gov"))
         .entry(Entry::default()
             .title(Text::new("NASA Television to Broadcast Space Station Departure of Cygnus Cargo Ship".into()))
-            .link(Link::new("\n                http://www.nasa.gov/press-release/nasa-television-to-broadcast-space-station-departure-of-cygnus-cargo-ship\n            ", None))
+            .link(Link::new("http://www.nasa.gov/press-release/nasa-television-to-broadcast-space-station-departure-of-cygnus-cargo-ship", None))
             .summary(Text::html(r#"More than three months after delivering several tons of supplies and scientific experiments to
                 the International Space Station, Northrop Grumman’s Cygnus cargo spacecraft, the SS Roger Chaffee, will
                 depart the orbiting laboratory Tuesday, Aug. 6.
             "#.to_owned()))
-            .id("\n                http://www.nasa.gov/press-release/nasa-television-to-broadcast-space-station-departure-of-cygnus-cargo-ship\n            ")
+            .id("http://www.nasa.gov/press-release/nasa-television-to-broadcast-space-station-departure-of-cygnus-cargo-ship")
             .published_rfc2822("Thu, 01 Aug 2019 16:15 EDT")
             .updated(actual.updated)
             .media(MediaObject::default()
@@ -88,7 +88,7 @@ fn test_example_3() {
     let expected = Feed::new(FeedType::RSS2)
         .id(actual.id.as_ref())     // not present in the test data
         .title(Text::new("News, Politics, Opinion, Commentary, and Analysis".into()))
-        .description(Text::new("In-depth reporting, commentary on breaking news, political analysis, and opinion from The New\n            Yorker.\n        ".into()))
+        .description(Text::new("In-depth reporting, commentary on breaking news, political analysis, and opinion from The New\n            Yorker.".into()))
         .link(Link::new("https://www.newyorker.com/news", None))
         .link(Link::new("https://www.newyorker.com/feed/news/rss", None)
             .rel("self")
@@ -98,7 +98,7 @@ fn test_example_3() {
         .updated_rfc2822("Tue, 06 Aug 2019 10:46:05 +0000")
         .entry(Entry::default()
             .title(Text::new("How a Historian Uncovered Ronald Reagan’s Racist Remarks to Richard Nixon".into()))
-            .link(Link::new("\n                https://www.newyorker.com/news/q-and-a/how-a-historian-uncovered-ronald-reagans-racist-remarks-to-richard-nixon\n            ", None))
+            .link(Link::new("https://www.newyorker.com/news/q-and-a/how-a-historian-uncovered-ronald-reagans-racist-remarks-to-richard-nixon", None))
             .id("5d420f3abfe6c20008d5eaad")
             .author(Person::new("Isaac Chotiner"))
             .summary(Text::html("Isaac Chotiner talks with the historian Tim Naftali, who published the text and audio of a\n                taped call, from 1971, in which Reagan described the African delegates to the U.N. in luridly racist\n                terms.\n            ".into()))
@@ -136,13 +136,13 @@ fn test_example_4() {
         .entry(Entry::default()
             .title(Text::new("Minor earthquake, 3.5 mag was detected near Aris in Greece".into()))
             .author(Person::new("admin"))
-            .link(Link::new("\n                http://www.earthquakenewstoday.com/2019/08/06/minor-earthquake-3-5-mag-was-detected-near-aris-in-greece/\n            ", None))
+            .link(Link::new("http://www.earthquakenewstoday.com/2019/08/06/minor-earthquake-3-5-mag-was-detected-near-aris-in-greece/", None))
             .published_rfc2822("Tue, 06 Aug 2019 05:01:15 +0000")
             .category(Category::new("Earthquake breaking news"))
             .category(Category::new("Minor World Earthquakes Magnitude -3.9"))
             .category(Category::new("Spárti"))
-            .id("\n                http://www.earthquakenewstoday.com/2019/08/06/minor-earthquake-3-5-mag-was-detected-near-aris-in-greece/\n            ")
-            .summary(Text::html("\n                A minor earthquake magnitude 3.5 (ml/mb) strikes near Kalamáta, Trípoli, Pýrgos, Spárti, Filiatrá, Messíni, Greece on Tuesday.".into()))
+            .id("http://www.earthquakenewstoday.com/2019/08/06/minor-earthquake-3-5-mag-was-detected-near-aris-in-greece/")
+            .summary(Text::html("A minor earthquake magnitude 3.5 (ml/mb) strikes near Kalamáta, Trípoli, Pýrgos, Spárti, Filiatrá, Messíni, Greece on Tuesday.".into()))
             .content(Content::default()
                 .body("<p><img class='size-full alignleft' title='Earthquake location 37.102S, 21.9072W' alt='Earthquake location 37.102S, 21.9072W' src='http://www.earthquakenewstoday.com/wp-content/uploads/35_20.jpg' width='146' height='146' />A minor earthquake with magnitude 3.5 (ml/mb) was detected on Tuesday, 8 kilometers (5 miles) from Aris in Greece.Exact location of event, depth 10 km, 21.9072&deg; East, 37.102&deg; North. </p>")
                 .content_type("text/html"))
@@ -382,7 +382,7 @@ fn test_spiegel() {
         )
         .entry(
             Entry::default()
-                .title(Text::new("07.02. – die Wochenvorschau: Lockdown-Verlängerung, Kriegsverbrecher vor Gericht, Super Bowl, Karneval ".into()))
+                .title(Text::new("07.02. – die Wochenvorschau: Lockdown-Verlängerung, Kriegsverbrecher vor Gericht, Super Bowl, Karneval".into()))
                 .content(Content::default().body(r#"Die wichtigsten Nachrichten aus der SPIEGEL-Redaktion. <br><br><p>See <a href="https://omnystudio.com/listener">omnystudio.com/listener</a> for privacy information.</p>"#).content_type("text/html"))
                 .summary(Text::html("Die wichtigsten Nachrichten aus der SPIEGEL-Redaktion. \r\nSee omnystudio.com/listener for privacy information.".into()))
                 .link(Link::new("https://omny.fm/shows/spiegel-update-die-nachrichten/07-02-die-wochenvorschau-lockdown-verl-ngerung-kri", None))
@@ -505,7 +505,7 @@ fn test_ch9() {
                 .link("https://s.ch9.ms/Shows/Azure-Friday"),
         )
         .description(Text::new(
-            "Join Scott Hanselman, Donovan Brown, or Lara Rubbelke as they host the engineers who build Azure, demo it, answer questions, and share insights. "
+            "Join Scott Hanselman, Donovan Brown, or Lara Rubbelke as they host the engineers who build Azure, demo it, answer questions, and share insights."
                 .into(),
         ))
         .link(
@@ -718,4 +718,20 @@ fn test_rfc1123_ilmessaggero() {
 
     // Should have the expected date
     assert_eq!(entry.published.unwrap(), Utc.with_ymd_and_hms(2022, 11, 15, 23, 38, 15).unwrap());
+}
+
+// Verifies we trim leading and trailing whitespace in text fields
+// e.g. those with newlines before the CDATA
+#[test]
+fn test_trim_whitespace_text_nodes() {
+    let test_data = test::fixture_as_string("rss_2.0_nightvale.xml");
+    let actual = parser::parse(test_data.as_bytes()).unwrap();
+
+    assert!(actual.description.unwrap().content.starts_with("<p>Twice-monthly community updates"));
+
+    let entry = actual.entries.get(0).expect("feed has 1 entry");
+    assert!(entry.summary.as_ref().unwrap().content.starts_with("<p>The University of What It Is"));
+
+    let media = entry.media.get(0).expect("entry has 1 media item");
+    assert!(media.description.as_ref().unwrap().content.starts_with("The University of What It Is"));
 }


### PR DESCRIPTION
The original issue described extraneous whitespace around cdata
elements, but exploring further finds this is a problem in IDs, links,
summaries etc.

This change trims leading and trailing whitespace only at a field level.
It does not trim whitespace around embedded elements (e.g. hrefs within
html content).

Fixes https://github.com/feed-rs/feed-rs/issues/163