### PR TITLE
Add generated-feed-id-compat feature which makes generated feed IDs compatible with feed-rs 0.2.4

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -21,6 +21,9 @@ readme = "README.md"
 [badges]
 travis-ci = { repository = "feed-rs/feed-rs", branch = "master" }
 
+[features]
+generated-feed-id-compat = []
+
 [dependencies]
 chrono = { version = "0.4.26", default-features = false }
 lazy_static = "1.4.0"

--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -633,8 +633,14 @@ pub struct Link {
 impl Link {
     pub(crate) fn new<S: AsRef<str>>(href: S, base: Option<&Url>) -> Link {
         let href = match util::parse_uri(href.as_ref(), base) {
-            Some(uri) => uri.to_string(),
-            None => href.as_ref().to_string(),
+            Some(uri) => {
+                let mut ret: String = uri.into();
+                if cfg!(feature="generated-feed-id-compat") && ret.ends_with('/') && !href.as_ref().ends_with('/') {
+                    ret.pop();
+                }
+                ret
+            }
+            None => href.as_ref().to_string()
         }
         .trim()
         .to_string();

--- a/feed-rs/src/parser/mod.rs
+++ b/feed-rs/src/parser/mod.rs
@@ -177,8 +177,8 @@ const LINK_HASH_KEY2: u64 = 0x90ee_ca4c_90a5_e228;
 
 // Creates a unique ID from the first link, or a UUID if no links are available
 fn create_id(links: &[model::Link], title: &Option<model::Text>, uri: Option<&str>) -> String {
-    if let Some(link) = links.iter().next() {
-        // Generate a stable ID for this item based on the first link
+    if let Some(link) = links.iter().filter(|l| !cfg!(feature="generated-feed-id-compat") || l.rel.is_none()).next() {
+        // Generate a stable ID for this item based on the first (non-atom) link
         let mut hasher = SipHasher::new_with_keys(LINK_HASH_KEY1, LINK_HASH_KEY2);
         hasher.write(link.href.as_bytes());
         if let Some(title) = title {


### PR DESCRIPTION
These were broken in 74366acf01c581270f79671dea679551aa17f3e4 (fix in model.rs) and 242c993367313ba5ab6a4cf20e81b7aac9c80668 (fix in parser/mod.rs).

I need these to be stable for feembox. Hidden behind a config in case, well, someone else needs them to be stable against v1.1.0.