### PR TITLE
Allow custom timestamp parser to be a closure

### DIFF
--- a/feed-rs/src/parser/util.rs
+++ b/feed-rs/src/parser/util.rs
@@ -65,7 +65,7 @@ lazy_static! {
 static RFC1123_FORMAT_STR: &str = "%d %b %Y %H:%M:%S %z";
 
 /// Generified timestamp parser
-pub(crate) type TimestampParser = fn(&str) -> Option<DateTime<Utc>>;
+pub(crate) type TimestampParser = dyn Fn(&str) -> Option<DateTime<Utc>>;
 
 /// Handles <content:encoded>
 pub(crate) fn handle_encoded<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Text>> {


### PR DESCRIPTION
Thanks for fixing #182!

It would be very helpful if the timestamp parser could be a closure rather than a static function, so that values such as the format string or timezone could be passed in during construction.