### PR TITLE
Add support for Atom language attributes

### DIFF
--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -296,6 +296,9 @@ pub struct Entry {
     /// 2) a default for any other "media:*" elements found at the item level
     /// See the Atom tests for youtube and newscred for examples
     pub media: Vec<MediaObject>,
+
+    /// Atom (optional): The language specified on the item
+    pub language: Option<String>,
 }
 
 impl Default for Entry {
@@ -314,6 +317,7 @@ impl Default for Entry {
             source: None,
             rights: None,
             media: Vec::new(),
+            language: None,
         }
     }
 }
@@ -382,6 +386,11 @@ impl Entry {
 
     pub fn media(mut self, media: MediaObject) -> Self {
         self.media.push(media);
+        self
+    }
+
+    pub fn language(mut self, language: &str) -> Self {
+        self.language = Some(language.to_owned());
         self
     }
 }

--- a/feed-rs/src/parser/atom/mod.rs
+++ b/feed-rs/src/parser/atom/mod.rs
@@ -16,9 +16,8 @@ mod tests;
 /// Parses an Atom feed into our model
 pub(crate) fn parse_feed<R: BufRead>(parser: &Parser, root: Element<R>) -> ParseFeedResult<Feed> {
     let mut feed = Feed::new(FeedType::Atom);
-    feed.language = root.attr_value("xml:lang");
 
-
+    feed.language = util::handle_language_attr(&root);
 
     for child in root.children() {
         let child = child?;
@@ -147,12 +146,6 @@ fn handle_content<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Con
     }
 }
 
-
-// Handles an Atom <content> element
-fn handle_language<R: BufRead>(element: &Element<R>) -> Option<String> {
-    element.attr_value("xml:lang")
-}
-
 // Handles an Atom <entry>
 fn handle_entry<R: BufRead>(parser: &Parser, element: Element<R>) -> ParseFeedResult<Option<Entry>> {
     // Create a default MediaRSS content object for non-grouped elements
@@ -173,9 +166,9 @@ fn handle_entry<R: BufRead>(parser: &Parser, element: Element<R>) -> ParseFeedRe
             (NS::Atom, "author") => if_some_then(handle_person(child)?, |person| entry.authors.push(person)),
 
             (NS::Atom, "content") => {
-                entry.language = handle_language(&child);
+                entry.language = util::handle_language_attr(&child);
                 entry.content = handle_content(child)?;
-            },
+            }
 
             (NS::Atom, "link") => if_some_then(handle_link(child), |link| entry.links.push(link)),
 

--- a/feed-rs/src/parser/atom/mod.rs
+++ b/feed-rs/src/parser/atom/mod.rs
@@ -16,6 +16,10 @@ mod tests;
 /// Parses an Atom feed into our model
 pub(crate) fn parse_feed<R: BufRead>(parser: &Parser, root: Element<R>) -> ParseFeedResult<Feed> {
     let mut feed = Feed::new(FeedType::Atom);
+    feed.language = root.attr_value("xml:lang");
+
+
+
     for child in root.children() {
         let child = child?;
         match child.ns_and_tag() {

--- a/feed-rs/src/parser/atom/mod.rs
+++ b/feed-rs/src/parser/atom/mod.rs
@@ -147,6 +147,12 @@ fn handle_content<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Con
     }
 }
 
+
+// Handles an Atom <content> element
+fn handle_language<R: BufRead>(element: &Element<R>) -> Option<String> {
+    element.attr_value("xml:lang")
+}
+
 // Handles an Atom <entry>
 fn handle_entry<R: BufRead>(parser: &Parser, element: Element<R>) -> ParseFeedResult<Option<Entry>> {
     // Create a default MediaRSS content object for non-grouped elements
@@ -166,7 +172,10 @@ fn handle_entry<R: BufRead>(parser: &Parser, element: Element<R>) -> ParseFeedRe
 
             (NS::Atom, "author") => if_some_then(handle_person(child)?, |person| entry.authors.push(person)),
 
-            (NS::Atom, "content") => entry.content = handle_content(child)?,
+            (NS::Atom, "content") => {
+                entry.language = handle_language(&child);
+                entry.content = handle_content(child)?;
+            },
 
             (NS::Atom, "link") => if_some_then(handle_link(child), |link| entry.links.push(link)),
 

--- a/feed-rs/src/parser/atom/tests.rs
+++ b/feed-rs/src/parser/atom/tests.rs
@@ -55,6 +55,7 @@ fn test_example_2() {
 
     let expected = Feed::new(FeedType::Atom)
         .id("tag:theregister.co.uk,2005:feed/theregister.co.uk/science/")
+        .language("en")
         .title(Text::new("The Register - Science".into()))
         .link(Link::new("https://www.theregister.co.uk/science/headlines.atom", None)
             .rel("self")
@@ -223,6 +224,7 @@ fn test_example_6() {
 
     let expected = Feed::new(FeedType::Atom)
         .id("tag:github.com,2008:https://github.com/feed-rs/feed-rs/releases")
+        .language("en-US")
         .link(
             Link::new("https://github.com/feed-rs/feed-rs/releases", None)
                 .rel("alternate")

--- a/feed-rs/src/parser/atom/tests.rs
+++ b/feed-rs/src/parser/atom/tests.rs
@@ -26,6 +26,7 @@ fn test_example_1() {
                 .id("tag:example.org,2003:3.2397")
                 .title(Text::new("Atom draft-07 snapshot".into()))
                 .updated_parsed("2005-07-31T12:29:29Z")
+                .language("en")
                 .author(Person::new("Mark Pilgrim").uri("http://example.org/").email("f8dy@example.com"))
                 .link(Link::new("http://example.org/2005/04/02/atom", None).rel("alternate").media_type("text/html"))
                 .link(
@@ -123,6 +124,7 @@ fn test_example_3() {
             .rel("hub"))
         .entry(Entry::default()
             .title(Text::new("Time to Transfer Risk: Why Security Complexity & VPNs Are No Longer Sustainable".into()))
+            .language("en-us")
             .link(Link::new("http://feedproxy.google.com/~r/TheAkamaiBlog/~3/NnQEuqRSyug/time-to-transfer-risk-why-security-complexity-vpns-are-no-longer-sustainable.html", None)
                 .rel("alternate")
                 .media_type("text/html"))

--- a/feed-rs/src/parser/util.rs
+++ b/feed-rs/src/parser/util.rs
@@ -72,6 +72,11 @@ pub(crate) fn handle_encoded<R: BufRead>(element: Element<R>) -> ParseFeedResult
     Ok(element.children_as_string()?.map(Text::html))
 }
 
+// Handles "xml:lang" as an attribute (e.g. in Atom feeds)
+pub fn handle_language_attr<R: BufRead>(element: &Element<R>) -> Option<String> {
+    element.attr_value("xml:lang")
+}
+
 // Handles <link>
 pub(crate) fn handle_link<R: BufRead>(element: Element<R>) -> Option<Link> {
     element.child_as_text().map(|s| Link::new(s, element.xml_base.as_ref()))


### PR DESCRIPTION
An `entry` in an atom feed can specify a language via the `xml:lang` attribute. This adds support for that data. Thanks for maintaining the project!