### PR TITLE
parser/atom: handle xml:base attribute on content

### DIFF
--- a/feed-rs/fixture/atom/atom_xml_base.xml
+++ b/feed-rs/fixture/atom/atom_xml_base.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" >
+  <updated>2022-04-27T09:26:27+00:00</updated>
+  <id>https://numi.st/feed.xml</id>
+  <title type="html">my cool website title</title>
+  <entry>
+    <title type="html">my cool entry title</title>
+    <updated>2022-04-21T00:00:00+00:00</updated>
+    <id>https://numi.st/post/2022/travel-uke</id>
+    <content type="html" xml:base="https://numi.st/post/2022/travel-uke/">
+      <![CDATA[<p><img src="IMG_1232.jpeg" /></p>]]>
+    </content>
+    <author><name>Not Blank</name></author>
+  </entry>
+</feed>

--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -299,6 +299,9 @@ pub struct Entry {
 
     /// Atom (optional): The language specified on the item
     pub language: Option<String>,
+    /// Atom (optional): The base url specified on the item to resolve any relative
+    /// references found within the scope on the item
+    pub base: Option<String>,
 }
 
 impl Default for Entry {
@@ -318,6 +321,7 @@ impl Default for Entry {
             rights: None,
             media: Vec::new(),
             language: None,
+            base: None,
         }
     }
 }
@@ -391,6 +395,11 @@ impl Entry {
 
     pub fn language(mut self, language: &str) -> Self {
         self.language = Some(language.to_owned());
+        self
+    }
+
+    pub fn base(mut self, url: &str) -> Self {
+        self.base = Some(url.to_owned());
         self
     }
 }

--- a/feed-rs/src/parser/atom/mod.rs
+++ b/feed-rs/src/parser/atom/mod.rs
@@ -166,6 +166,7 @@ fn handle_entry<R: BufRead>(parser: &Parser, element: Element<R>) -> ParseFeedRe
             (NS::Atom, "author") => if_some_then(handle_person(child)?, |person| entry.authors.push(person)),
 
             (NS::Atom, "content") => {
+                entry.base = util::handle_base_attr(&child);
                 entry.language = util::handle_language_attr(&child);
                 entry.content = handle_content(child)?;
             }

--- a/feed-rs/src/parser/atom/tests.rs
+++ b/feed-rs/src/parser/atom/tests.rs
@@ -27,6 +27,7 @@ fn test_example_1() {
                 .title(Text::new("Atom draft-07 snapshot".into()))
                 .updated_parsed("2005-07-31T12:29:29Z")
                 .language("en")
+                .base("http://diveintomark.org/")
                 .author(Person::new("Mark Pilgrim").uri("http://example.org/").email("f8dy@example.com"))
                 .link(Link::new("http://example.org/2005/04/02/atom", None).rel("alternate").media_type("text/html"))
                 .link(
@@ -125,6 +126,7 @@ fn test_example_3() {
         .entry(Entry::default()
             .title(Text::new("Time to Transfer Risk: Why Security Complexity & VPNs Are No Longer Sustainable".into()))
             .language("en-us")
+            .base("https://blogs.akamai.com/")
             .link(Link::new("http://feedproxy.google.com/~r/TheAkamaiBlog/~3/NnQEuqRSyug/time-to-transfer-risk-why-security-complexity-vpns-are-no-longer-sustainable.html", None)
                 .rel("alternate")
                 .media_type("text/html"))
@@ -560,4 +562,12 @@ fn test_scattered() {
         .as_ref()
         .unwrap()
         .contains("there are no strings on me"));
+}
+
+// Handle xml:base attribute on content
+#[test]
+fn test_atom_content_xml_base() {
+    let test_data = test::fixture_as_string("atom/atom_xml_base.xml");
+    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    assert!(actual.entries[0].base.as_ref().unwrap().eq("https://numi.st/post/2022/travel-uke/"));
 }

--- a/feed-rs/src/parser/util.rs
+++ b/feed-rs/src/parser/util.rs
@@ -77,6 +77,11 @@ pub(crate) fn handle_language_attr<R: BufRead>(element: &Element<R>) -> Option<S
     element.attr_value("xml:lang")
 }
 
+// Handles "xml:base" as an attribute (e.g. in Atom feeds)
+pub(crate) fn handle_base_attr<R: BufRead>(element: &Element<R>) -> Option<String> {
+    element.attr_value("xml:base")
+}
+
 // Handles <link>
 pub(crate) fn handle_link<R: BufRead>(element: Element<R>) -> Option<Link> {
     element.child_as_text().map(|s| Link::new(s, element.xml_base.as_ref()))


### PR DESCRIPTION
this add the base attribute found on ATOM entry.

fix #211 