### PR TITLE
Implement ID generator v0.2 on builder

### DIFF
--- a/feed-rs/src/parser/mod.rs
+++ b/feed-rs/src/parser/mod.rs
@@ -258,6 +258,24 @@ impl Builder {
         self
     }
 
+    /// Registers an ID generator compatible with v0.2 of feed-rs
+    pub fn id_generator_v0_2(self) -> Self {
+        self.id_generator(|links, title, _uri| {
+            // If we have a link without relative components, use that
+            if let Some(link) = links.iter().find(|l| l.rel.is_none()) {
+                // Trim the trailing slash if it exists
+                let mut link = model::Link::new(link.href.clone(), None);
+                if link.href.ends_with('/') {
+                    link.href.pop();
+                }
+
+                generate_id_from_link_and_title(&link, title)
+            } else {
+                util::uuid_gen()
+            }
+        })
+    }
+
     /// Registers a custom timestamp parser
     pub fn timestamp_parser<F>(mut self, ts_parser: F) -> Self
     where

--- a/feed-rs/src/parser/tests.rs
+++ b/feed-rs/src/parser/tests.rs
@@ -1,6 +1,4 @@
-use crate::model::Link;
 use crate::parser;
-use crate::parser::{generate_id_from_link_and_title, util};
 use crate::util::test;
 
 // Regression test for the default ID generator
@@ -9,33 +7,6 @@ fn id_generator_default() {
     let test_data = test::fixture_as_raw("rss2/rss_2.0_kdist.xml");
     let feed = parser::parse(test_data.as_slice()).unwrap();
     assert_eq!("354331764be7571efc15c7a1bad13d54", feed.id);
-}
-
-// Custom implementation providing backward compatibility with v0.2
-#[test]
-fn id_generator_v0_2() {
-    let test_data = test::fixture_as_raw("rss2/rss_2.0_kdist.xml");
-
-    // Custom ID that trims URLs etc
-    let feed = parser::Builder::new()
-        .id_generator(|links, title, _uri| {
-            // If we have a link without relative components, use that
-            if let Some(link) = links.iter().find(|l| l.rel.is_none()) {
-                // Trim the trailing slash if it exists
-                let mut link = Link::new(link.href.clone(), None);
-                if link.href.ends_with('/') {
-                    link.href.pop();
-                }
-
-                generate_id_from_link_and_title(&link, title)
-            } else {
-                util::uuid_gen()
-            }
-        })
-        .build()
-        .parse(test_data.as_slice())
-        .unwrap();
-    assert_eq!("7edcf1fbe86570753646f6eb75db4d55", feed.id);
 }
 
 // Verifies failure uncovered by fuzzing is now fixed

--- a/feed-rs/tests/id_generator.rs
+++ b/feed-rs/tests/id_generator.rs
@@ -1,0 +1,16 @@
+use std::fs;
+use std::path::PathBuf;
+
+use feed_rs::parser;
+
+// Verify we can generate IDs that are compatible with v0.2
+#[test]
+fn test_feed_ids_v0_2() {
+    let mut test_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    test_file.push("fixture/rss2/rss_2.0_kdist.xml");
+    let test_data = fs::read(test_file).unwrap();
+
+    // Use the v0.2 ID generator
+    let feed = parser::Builder::new().id_generator_v0_2().build().parse(test_data.as_slice()).unwrap();
+    assert_eq!("7edcf1fbe86570753646f6eb75db4d55", feed.id);
+}


### PR DESCRIPTION
To avoid leaking internal logic, the v0.2 ID generator is now a method on the parser builder.