### PR TITLE
Switch to mediatype crate

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -23,7 +23,7 @@ travis-ci = { repository = "feed-rs/feed-rs", branch = "master" }
 
 [dependencies]
 chrono = { version = "0.4.38", default-features = false }
-mime = "0.3.17"
+mediatype = "0.19.18"
 quick-xml = { version = "0.31.0", features = ["encoding"] }
 regex = "1.10.4"
 serde = { version = "1.0.198", features = ["derive"] }

--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -1,12 +1,12 @@
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use mime::Mime;
+use mediatype::{names, MediaTypeBuf};
+use url::Url;
 
-use crate::parser::util;
 #[cfg(test)]
 use crate::parser::util::parse_timestamp_lenient;
-use url::Url;
+use crate::parser::util::parse_uri;
 
 /// Combined model for a syndication feed (i.e. RSS1, RSS 2, Atom, JSON Feed)
 ///
@@ -461,7 +461,7 @@ pub struct Content {
     /// Type of content
     /// * Atom: The type attribute is either text, html, xhtml, in which case the content element is defined identically to other text constructs.
     /// * RSS 2: Type says what its type is, a standard MIME type
-    pub content_type: Mime,
+    pub content_type: MediaTypeBuf,
     /// RSS 2.0: Length of the content in bytes
     pub length: Option<u64>,
     /// Source of the content
@@ -474,7 +474,7 @@ impl Default for Content {
     fn default() -> Content {
         Content {
             body: None,
-            content_type: mime::TEXT_PLAIN,
+            content_type: MediaTypeBuf::new(names::TEXT, names::PLAIN),
             length: None,
             src: None,
         }
@@ -489,7 +489,7 @@ impl Content {
     }
 
     pub fn content_type(mut self, content_type: &str) -> Self {
-        self.content_type = content_type.parse::<Mime>().unwrap();
+        self.content_type = content_type.parse::<MediaTypeBuf>().unwrap();
         self
     }
 
@@ -631,7 +631,7 @@ pub struct Link {
 
 impl Link {
     pub(crate) fn new<S: AsRef<str>>(href: S, base: Option<&Url>) -> Link {
-        let href = match util::parse_uri(href.as_ref(), base) {
+        let href = match parse_uri(href.as_ref(), base) {
             Some(uri) => uri.to_string(),
             None => href.as_ref().to_string(),
         }
@@ -799,7 +799,7 @@ pub struct MediaContent {
     /// The direct URL
     pub url: Option<Url>,
     /// Standard MIME type
-    pub content_type: Option<Mime>,
+    pub content_type: Option<MediaTypeBuf>,
     /// Height and width
     pub height: Option<u32>,
     pub width: Option<u32>,
@@ -814,7 +814,7 @@ pub struct MediaContent {
 #[cfg(test)]
 impl MediaContent {
     pub fn content_type(mut self, content_type: &str) -> Self {
-        self.content_type = Some(content_type.parse::<Mime>().unwrap());
+        self.content_type = Some(content_type.parse::<MediaTypeBuf>().unwrap());
         self
     }
 
@@ -968,7 +968,7 @@ impl Person {
 /// Textual content, or link to the content, for a given entry.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Text {
-    pub content_type: Mime,
+    pub content_type: MediaTypeBuf,
     pub src: Option<String>,
     pub content: String,
 }
@@ -976,7 +976,7 @@ pub struct Text {
 impl Text {
     pub(crate) fn new(content: String) -> Text {
         Text {
-            content_type: mime::TEXT_PLAIN,
+            content_type: MediaTypeBuf::new(names::TEXT, names::PLAIN),
             src: None,
             content: content.trim().to_string(),
         }
@@ -984,7 +984,7 @@ impl Text {
 
     pub(crate) fn html(content: String) -> Text {
         Text {
-            content_type: mime::TEXT_HTML,
+            content_type: MediaTypeBuf::new(names::TEXT, names::HTML),
             src: None,
             content: content.trim().to_string(),
         }
@@ -994,7 +994,7 @@ impl Text {
 #[cfg(test)]
 impl Text {
     pub fn content_type(mut self, content_type: &str) -> Self {
-        self.content_type = content_type.parse::<Mime>().unwrap();
+        self.content_type = content_type.parse::<MediaTypeBuf>().unwrap();
         self
     }
 }

--- a/feed-rs/src/parser/itunes.rs
+++ b/feed-rs/src/parser/itunes.rs
@@ -1,10 +1,11 @@
+use std::io::BufRead;
+use std::time::Duration;
+
 use crate::model::{Category, Feed, Image, MediaCredit, MediaObject, MediaRating, MediaThumbnail, Person};
 use crate::parser::atom;
 use crate::parser::util::{if_some_then, parse_npt};
 use crate::parser::ParseFeedResult;
 use crate::xml::{Element, NS};
-use std::io::BufRead;
-use std::time::Duration;
 
 // Process <itunes> elements at channel level updating the Feed object as required
 pub(crate) fn handle_itunes_channel_element<R: BufRead>(element: Element<R>, feed: &mut Feed) -> ParseFeedResult<()> {

--- a/feed-rs/src/parser/json/mod.rs
+++ b/feed-rs/src/parser/json/mod.rs
@@ -1,6 +1,6 @@
 use std::io::Read;
 
-use mime::Mime;
+use mediatype::{names, MediaTypeBuf};
 
 use crate::model::{Category, Content, Entry, Feed, FeedType, Image, Link, Person, Text};
 use crate::parser::util::if_some_then;
@@ -100,7 +100,7 @@ fn handle_authors(accumulated: &mut Vec<Person>, author: &Option<JsonAuthor>, au
 }
 
 // Handles HTML or plain text content
-fn handle_content(content: Option<String>, content_type: Mime) -> Option<Content> {
+fn handle_content(content: Option<String>, content_type: MediaTypeBuf) -> Option<Content> {
     content.map(|body| Content {
         length: Some(body.as_bytes().len() as u64),
         body: Some(body.trim().into()),
@@ -123,9 +123,9 @@ fn handle_item(parser: &Parser, ji: JsonItem) -> Entry {
     if_some_then(ji.title, |text| entry.title = Some(Text::new(text)));
 
     // Content HTML, content text and summary are mapped across to our model with the preference toward HTML and explicit summary fields
-    entry.content = handle_content(ji.content_html, mime::TEXT_HTML);
+    entry.content = handle_content(ji.content_html, MediaTypeBuf::new(names::TEXT, names::HTML));
     entry.summary = ji.summary.map(Text::new);
-    if let Some(content_text) = handle_content(ji.content_text, mime::TEXT_PLAIN) {
+    if let Some(content_text) = handle_content(ji.content_text, MediaTypeBuf::new(names::TEXT, names::PLAIN)) {
         // If we don't have HTML content, use the text content as the entry content
         // otherwise, if the summary was not provided, we push the text there
 

--- a/feed-rs/src/parser/rss1/tests.rs
+++ b/feed-rs/src/parser/rss1/tests.rs
@@ -1,3 +1,5 @@
+use mediatype::{names, MediaType};
+
 use crate::model::{Entry, Feed, FeedType, Image, Link, Person, Text};
 use crate::parser;
 use crate::util::test;
@@ -61,7 +63,7 @@ fn test_example_2() {
         .unwrap()
         .starts_with("This morning I saw two things that were Microsoft "));
     // content media type should be text/html.
-    assert_eq!(feed.entries[0].content.as_ref().unwrap().content_type, "text/html");
+    assert_eq!(feed.entries[0].content.as_ref().unwrap().content_type, MediaType::new(names::TEXT, names::HTML));
 }
 
 // Example 1 from the spec at https://validator.w3.org/feed/docs/rss1.html

--- a/feed-rs/src/parser/rss2/mod.rs
+++ b/feed-rs/src/parser/rss2/mod.rs
@@ -1,6 +1,6 @@
 use std::io::BufRead;
 
-use mime::Mime;
+use mediatype::{names, MediaTypeBuf};
 
 use crate::model::{Category, Content, Entry, Feed, FeedType, Generator, Image, Link, MediaContent, MediaObject, Person};
 use crate::parser::itunes::{handle_itunes_channel_element, handle_itunes_item_element};
@@ -123,7 +123,7 @@ fn handle_enclosure<R: BufRead>(element: Element<R>, media_obj: &mut MediaObject
         match tag_name {
             "url" => content.url = util::parse_uri(&attr.value, element.xml_base.as_ref()),
             "length" => content.size = attr.value.parse::<u64>().ok(),
-            "type" => if_ok_then_some(attr.value.parse::<Mime>(), |mime| content.content_type = mime),
+            "type" => if_ok_then_some(attr.value.parse::<MediaTypeBuf>(), |mime| content.content_type = mime),
 
             // Nothing required for unknown elements
             _ => {}
@@ -186,7 +186,7 @@ fn handle_content_encoded<R: BufRead>(element: Element<R>) -> ParseFeedResult<Op
         } else {
             Some(Content {
                 body: Some(string),
-                content_type: mime::TEXT_HTML,
+                content_type: MediaTypeBuf::new(names::TEXT, names::HTML),
                 src,
                 ..Default::default()
             })

--- a/feed-rs/src/parser/rss2/tests.rs
+++ b/feed-rs/src/parser/rss2/tests.rs
@@ -1,11 +1,13 @@
-use chrono::{TimeZone, Utc};
 use std::time::Duration;
+
+use chrono::{TimeZone, Utc};
+use mediatype::{names, MediaType};
+use url::Url;
 
 use crate::model::*;
 use crate::parser;
 use crate::parser::util;
 use crate::util::test;
-use url::Url;
 
 // Basic example from various sources (Wikipedia etc).
 #[test]
@@ -330,7 +332,7 @@ fn test_heated() {
     let feed = parser::parse(test_data.as_slice()).unwrap();
     let content = &feed.entries[0].content.as_ref().unwrap();
     assert!(content.body.as_ref().unwrap().contains("I have some good news and some bad news"));
-    assert_eq!(content.content_type, "text/html");
+    assert_eq!(content.content_type, MediaType::new(names::TEXT, names::HTML));
 }
 
 // Check reported issue that RockPaperShotgun does not extract summary

--- a/feed-rs/src/parser/util.rs
+++ b/feed-rs/src/parser/util.rs
@@ -4,22 +4,23 @@ use std::ops::Add;
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use crate::model;
 use chrono::{DateTime, Utc};
-use model::{Link, Text};
 use regex::{Captures, Regex};
 use url::Url;
 use uuid::Uuid;
 
+use fixes::PatSub;
+use model::{Link, Text};
+
+use crate::model;
 use crate::parser::{ParseFeedResult, Parser};
 use crate::xml::Element;
-
-use fixes::PatSub;
 
 /// Set of regular expressions we use to clean up broken dates
 mod fixes {
     use super::OnceLock;
     use super::Regex;
+
     pub struct PatSub(pub Regex, pub &'static str);
 
     // Feeds may not comply with the specification

--- a/feed-rs/src/xml/tests.rs
+++ b/feed-rs/src/xml/tests.rs
@@ -1,9 +1,9 @@
+use std::error::Error;
 use std::io::BufRead;
 
 use crate::util::test;
 
 use super::*;
-use std::error::Error;
 
 type TestResult = std::result::Result<(), Box<dyn Error>>;
 


### PR DESCRIPTION
The mime crate is no longer maintained per
https://github.com/hyperium/mime/issues/153

The mediatype is a reasonable replacement, and actively maintained. 
https://crates.io/crates/mediatype/