### PR TITLE
build: upgrade to quick-xml 0.36

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -24,7 +24,7 @@ travis-ci = { repository = "feed-rs/feed-rs", branch = "master" }
 [dependencies]
 chrono = { version = "0.4.38", default-features = false }
 mediatype = "0.19.18"
-quick-xml = { version = "0.31.0", features = ["encoding"] }
+quick-xml = { version = "0.36.0", features = ["encoding"] }
 regex = "1.10.4"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"

--- a/feed-rs/src/parser/atom/tests.rs
+++ b/feed-rs/src/parser/atom/tests.rs
@@ -351,8 +351,7 @@ fn test_example_7() {
     let test_data = test::fixture_as_string("atom/atom_example_7.xml");
     let feed = parser::parse(test_data.as_bytes()).unwrap();
     let body = feed
-        .entries
-        .get(0)
+        .entries.first()
         .map(|e| e.content.as_ref())
         .unwrap()
         .map(|c| c.body.as_ref())

--- a/feed-rs/src/parser/rss0/tests.rs
+++ b/feed-rs/src/parser/rss0/tests.rs
@@ -10,7 +10,7 @@ fn test_0_91_spec_1() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let entry0 = actual.entries.get(0).unwrap();
+    let entry0 = actual.entries.first().unwrap();
     let entry1 = actual.entries.get(1).unwrap();
     let expected = Feed::new(FeedType::RSS0)
         .id(actual.id.as_ref())     // not present in the test data
@@ -89,7 +89,7 @@ fn test_0_92_spec_1() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let entry0 = actual.entries.get(0).unwrap();
+    let entry0 = actual.entries.first().unwrap();
     let entry1 = actual.entries.get(1).unwrap();
     let entry2 = actual.entries.get(2).unwrap();
     let expected = Feed::new(FeedType::RSS0)

--- a/feed-rs/src/parser/rss1/tests.rs
+++ b/feed-rs/src/parser/rss1/tests.rs
@@ -12,7 +12,7 @@ fn test_example_1() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let entry0 = actual.entries.get(0).unwrap();
+    let entry0 = actual.entries.first().unwrap();
     let entry1 = actual.entries.get(1).unwrap();
     let expected = Feed::new(FeedType::RSS1)
         .id(actual.id.as_ref()) // not present in the test data
@@ -74,7 +74,7 @@ fn test_spec_1() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let entry0 = actual.entries.get(0).unwrap();
+    let entry0 = actual.entries.first().unwrap();
     let entry1 = actual.entries.get(1).unwrap();
     let expected = Feed::new(FeedType::RSS1)
         .id(actual.id.as_ref())     // not present in the test data
@@ -110,7 +110,7 @@ fn test_spec_2() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let entry0 = actual.entries.get(0).unwrap();
+    let entry0 = actual.entries.first().unwrap();
     let expected = Feed::new(FeedType::RSS1)
         .id(actual.id.as_ref()) // not present in the test data
         .title(Text::new("Meerkat".into()))
@@ -146,7 +146,7 @@ fn test_spec_2() {
 fn test_debian() {
     let test_data = test::fixture_as_string("rss1/rss_1.0_debian.xml");
     let actual = parser::parse(test_data.as_bytes()).unwrap();
-    let entry = actual.entries.get(0).expect("feed has 1 entry");
+    let entry = actual.entries.first().expect("feed has 1 entry");
 
     assert!(entry.published.is_some());
 }
@@ -156,7 +156,7 @@ fn test_debian() {
 fn test_iso8859() {
     let test_data = test::fixture_as_raw("rss1/rss_1.0_iso8859.xml");
     let actual = parser::parse(test_data.as_slice()).unwrap();
-    let entry = actual.entries.get(0).expect("feed has 1 entry");
+    let entry = actual.entries.first().expect("feed has 1 entry");
 
     let expected = "Ab April soll es wieder Förderung für den Ausbau von Glasfaser geben.";
     let summary = &entry.summary.as_ref().unwrap().content;

--- a/feed-rs/src/parser/rss2/tests.rs
+++ b/feed-rs/src/parser/rss2/tests.rs
@@ -249,11 +249,11 @@ fn test_wirecutter() {
     let test_data = test::fixture_as_string("rss2/rss_2.0_wirecutter.xml");
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
-    let entry = actual.entries.get(0).expect("sample feed has one entry");
-    let category = entry.categories.get(0).expect("entry has one category");
+    let entry = actual.entries.first().expect("sample feed has one entry");
+    let category = entry.categories.first().expect("entry has one category");
     assert_eq!(category.term, "Uncategorized");
 
-    let author = entry.authors.get(0).expect("entry has one author");
+    let author = entry.authors.first().expect("entry has one author");
     assert_eq!(author.name, "James Austin");
 }
 
@@ -699,7 +699,7 @@ fn test_ghost_feeds() {
 fn test_matrix() {
     let test_data = test::fixture_as_string("rss2/rss_2.0_matrix.xml");
     let actual = parser::parse(test_data.as_bytes()).unwrap();
-    let entry = actual.entries.get(0).expect("feed has 1 entry");
+    let entry = actual.entries.first().expect("feed has 1 entry");
 
     // The content should not be present
     assert!(entry.content.is_none());
@@ -710,7 +710,7 @@ fn test_matrix() {
 fn test_rfc1123_ilgiornale() {
     let test_data = test::fixture_as_string("rss2/rss_2.0_ilgiornale.xml");
     let actual = parser::parse(test_data.as_bytes()).unwrap();
-    let entry = actual.entries.get(0).expect("feed has 1 entry");
+    let entry = actual.entries.first().expect("feed has 1 entry");
 
     // Should have the expected date
     assert_eq!(entry.published.unwrap(), Utc.with_ymd_and_hms(2022, 11, 15, 20, 15, 4).unwrap());
@@ -721,7 +721,7 @@ fn test_rfc1123_ilgiornale() {
 fn test_rfc1123_ilmessaggero() {
     let test_data = test::fixture_as_string("rss2/rss_2.0_ilmessaggero.xml");
     let actual = parser::parse(test_data.as_bytes()).unwrap();
-    let entry = actual.entries.get(0).expect("feed has 1 entry");
+    let entry = actual.entries.first().expect("feed has 1 entry");
 
     // Should have the expected date
     assert_eq!(entry.published.unwrap(), Utc.with_ymd_and_hms(2022, 11, 15, 23, 38, 15).unwrap());
@@ -736,10 +736,10 @@ fn test_trim_whitespace_text_nodes() {
 
     assert!(actual.description.unwrap().content.starts_with("<p>Twice-monthly community updates"));
 
-    let entry = actual.entries.get(0).expect("feed has 1 entry");
+    let entry = actual.entries.first().expect("feed has 1 entry");
     assert!(entry.summary.as_ref().unwrap().content.starts_with("<p>The University of What It Is"));
 
-    let media = entry.media.get(0).expect("entry has 1 media item");
+    let media = entry.media.first().expect("entry has 1 media item");
     assert!(media.description.as_ref().unwrap().content.starts_with("The University of What It Is"));
 }
 
@@ -748,7 +748,7 @@ fn test_trim_whitespace_text_nodes() {
 fn test_published_from_dc_date() {
     let test_data = test::fixture_as_string("rss2/rss_2.0_dbengines.xml");
     let actual = parser::parse(test_data.as_bytes()).unwrap();
-    let entry = actual.entries.get(0).expect("feed has 1 entry");
+    let entry = actual.entries.first().expect("feed has 1 entry");
     assert_eq!(entry.published.unwrap(), Utc.with_ymd_and_hms(2023, 1, 3, 15, 0, 0).unwrap());
 }
 
@@ -768,7 +768,7 @@ fn test_custom_timestamp_parser() {
         .build()
         .parse(test_data.as_bytes())
         .unwrap();
-    let entry = actual.entries.get(0).expect("feed has 1 entry");
+    let entry = actual.entries.first().expect("feed has 1 entry");
     assert_eq!(entry.published.unwrap(), Utc.with_ymd_and_hms(2023, 12, 16, 19, 2, 33).unwrap());
 }
 

--- a/feed-rs/src/xml/mod.rs
+++ b/feed-rs/src/xml/mod.rs
@@ -32,7 +32,10 @@ impl<R: BufRead> ElementSource<R> {
     pub(crate) fn new(xml_data: R, xml_base_uri: Option<&str>) -> XmlResult<ElementSource<R>> {
         // Create the XML parser
         let mut reader = NsReader::from_reader(xml_data);
-        reader.expand_empty_elements(true).trim_markup_names_in_closing_tags(true).trim_text(false);
+        let config = reader.config_mut();
+        config.expand_empty_elements = true;
+        config.trim_markup_names_in_closing_tags = true;
+        config.trim_text(false);
 
         let state = RefCell::new(SourceState::new(reader, xml_base_uri)?);
         Ok(ElementSource { state })
@@ -151,8 +154,8 @@ impl<R: BufRead> ElementSource<R> {
 
         // Hit the end of the document
         if state.current_depth > 0 {
-            let msg = format!("documented terminated at depth {}", state.current_depth);
-            let e = quick_xml::Error::UnexpectedEof(msg);
+            // let msg = format!("documented terminated at depth {}", state.current_depth);
+            let e = quick_xml::Error::Syntax(quick_xml::errors::SyntaxError::UnclosedTag);
             Err(XmlError::Parser { e })
         } else {
             Ok(None)


### PR DESCRIPTION
There are minor breaking changes in the new version regarding configuring values and handling errors. A previous error message indicating the last depth at which a failure occurred has been dropped due to quick-xml error values no longer allowing arbitrary strings in the variant data. See [v32](https://github.com/tafia/quick-xml/releases/tag/v0.32.0) and [the docs](https://docs.rs/quick-xml/latest/quick_xml/errors/enum.Error.html) for more details.