### PR TITLE
Add support for the `src` attribute for `atom:content`.

### DIFF
--- a/feed-rs/fixture/atom/atom_content_src.xml
+++ b/feed-rs/fixture/atom/atom_content_src.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>~elly/blog</title>
+  <link href="https://elly.town/d/blog/"/>
+  <link rel="self" href="https://elly.town/feed.xml"/>
+  <updated>2024-03-08T00:00:00Z</updated>
+  <author><name>elly</name></author>
+  <id>urn:uuid:58e1c539-4056-4502-9445-29d725e4df97</id>
+  <entry>
+    <content src="https://elly.town/d/blog/2024-03-08-x509-certificates.txt" type="text/plain"/>
+    <id>urn:uuid:2c43eb19-7261-4a41-9225-4dc421f9a1b7</id>
+    <link href="https://elly.town/d/blog/2024-03-08-x509-certificates.txt"/>
+    <summary>How do X.509 certificates actually work, and what's actually inside them?</summary>
+    <title>X.509 Certificates</title>
+    <updated>2024-03-08T00:00:00Z</updated>
+  </entry>
+</feed>

--- a/feed-rs/src/parser/atom/mod.rs
+++ b/feed-rs/src/parser/atom/mod.rs
@@ -95,6 +95,42 @@ fn handle_content<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Con
     // Extract the content type so we can parse the body
     let content_type = element.attr_value("type");
 
+    if let Some(src) = element.attr_value("src") {
+        // > If the "src" attribute is present, the "type" attribute SHOULD be provided and MUST be a MIME media type, rather than "text", "html", or "xhtml".
+        let mime = match &content_type {
+            Some(ct) => ct
+                .parse::<MediaTypeBuf>()
+                .map_err(|_| ParseFeedError::ParseError(ParseErrorKind::UnknownMimeType(ct.into())))?,
+            None => {
+                // According to the spec the content type only SHOULD be provided.
+                // Unfortunately `Content` has media type as required. So we treat a missing type as text/html as that is probably the most common. Not to mention that `body` will be `None` so we are just providing a content type for nothing.
+                MediaTypeBuf::new(names::TEXT, names::HTML)
+            }
+        };
+
+        if element.child_as_text().is_some() {
+            // > If the "src" attribute is present, atom:content MUST be empty.
+            // `ParseFeedError` has no appropriate error type, so use `MissingContent` which is what would have been returned before support for `src` was added.
+            return Err(ParseFeedError::ParseError(ParseErrorKind::MissingContent("non-empty atom:content with src")));
+        }
+
+        let content = Content {
+            body: None,
+            content_type: mime,
+            src: Some(Link {
+                href: src,
+                rel: None,
+                media_type: content_type,
+                href_lang: None,
+                title: None,
+                length: None,
+            }),
+            ..Default::default()
+        };
+
+        return Ok(Some(content));
+    }
+
     // from http://www.atomenabled.org/developers/syndication/#contentElement
     match content_type.as_deref() {
         // Should be handled as a text element per "In the most common case, the type attribute is either text, html, xhtml, in which case the content element is defined identically to other text constructs"

--- a/feed-rs/src/parser/atom/tests.rs
+++ b/feed-rs/src/parser/atom/tests.rs
@@ -568,6 +568,30 @@ fn test_scattered() {
         .contains("there are no strings on me"));
 }
 
+// Handle Atom atomOutOfLineContent
+#[test]
+fn test_atom_content_src() {
+    let test_data = test::fixture_as_string("atom/atom_content_src.xml");
+    let actual = parser::parse(test_data.as_bytes()).unwrap();
+
+    assert_eq!(
+        actual.entries[0].content,
+        Some(Content {
+            body: None,
+            content_type: "text/plain".parse().unwrap(),
+            src: Some(Link {
+                href: "https://elly.town/d/blog/2024-03-08-x509-certificates.txt".into(),
+                rel: None,
+                media_type: Some("text/plain".into()),
+                href_lang: None,
+                title: None,
+                length: None,
+            }),
+            ..Default::default()
+        }),
+    );
+}
+
 // Handle xml:base attribute on content
 #[test]
 fn test_atom_content_xml_base() {


### PR DESCRIPTION
This is described in https://datatracker.ietf.org/doc/html/rfc4287#section-4.1.3.2

Unfortunately the existing model types are a bit at odds with the spec. To avoid breaking backwards compatibility I had to be a bit creative with the types.

1. If the `content_type` is not provided we guess that it is `text/html` as the `Content` type requires a type. This is likely not an issue because the `body` is `None`.
2. There is no appropriate error value for having both content and src.

Both can be fixed in a future version when backwards compatibility is broken.

For 2 it may also make sense to just return `src` and `body`. The code could treat them mostly independently. For now it is an error, which can always be changed if this is seen in the wild.