### PR TITLE
Support media:player in Media RSS

### DIFF
--- a/feed-rs/fixture/rss2/rss_2.0_vimeo_media.xml
+++ b/feed-rs/fixture/rss2/rss_2.0_vimeo_media.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/"
+     xml:lang="en-US">
+    <channel>
+        <title>Vimeo / Failla Wines’s videos</title>
+        <link>https://vimeo.com/user110157601/videos</link>
+        <description>Videos uploaded by Failla Wines on Vimeo.</description>
+        <pubDate>Fri, 27 Sep 2024 12:29:11 -0400</pubDate>
+        <generator>Vimeo</generator>
+        <atom:link rel="self" href="https://vimeo.com/user110157601/videos/user110157601/videos/rss"/>
+        <atom:link rel="hub" href="http://vimeo.superfeedr.com"/>
+        <atom:link rel="hub" href="https://pubsubhubbub.appspot.com/"/>
+        <image>
+            <url>
+                https://i.vimeocdn.com/portrait/37345511_100x100?sig=7ea22cf7ad2c5ec6d16ca5351f582c363ff31e80edcd1013068b8840546565ae&amp;v=1
+            </url>
+            <title>Vimeo / Failla Wines’s videos</title>
+            <link>https://vimeo.com/user110157601/videos</link>
+        </image>
+        <item>
+            <title>Oregon Harvest Update and Fall Release Date Set</title>
+            <pubDate>Fri, 27 Sep 2024 12:29:11 -0400</pubDate>
+            <link>https://vimeo.com/1013595996</link>
+            <description>Also check the email for a few important dates in October you&amp;#039;ll want to mark on your
+                calendar!
+            </description>
+            <guid isPermaLink="false">tag:vimeo,2024-09-27:clip1013595996</guid>
+            <media:content medium="video" duration="610">
+                <media:player url="https://player.vimeo.com/video/1013595996?h=b1b80eff69"/>
+                <media:credit role="author" scheme="urn:ebu">Failla Wines</media:credit>
+                <media:thumbnail height="540" width="960"
+                                 url="https://i.vimeocdn.com/video/1931613648-ea51f2799c4a4a4e058ed673e5587a0449778336fb866fad28a1ef7703a848dc-d_960"/>
+                <media:title>Oregon Harvest Update and Fall Release Date Set</media:title>
+            </media:content>
+        </item>
+    </channel>
+</rss>

--- a/feed-rs/src/parser/rss2/tests.rs
+++ b/feed-rs/src/parser/rss2/tests.rs
@@ -399,7 +399,7 @@ fn test_spiegel() {
                     .credit("DER SPIEGEL")
                     .thumbnail(MediaThumbnail::new(Image::new("https://www.omnycontent.com/d/programs/5ac1e950-45c7-4eb7-87c0-aa0f018441b8/bb17ca27-51f4-4349-bc1e-abc00102c975/image.jpg?t=1589902935&size=Large".into())))
                     .content(MediaContent::new()
-                        .url("https://traffic.omny.fm/d/clips/5ac1e950-45c7-4eb7-87c0-aa0f018441b8/bb17ca27-51f4-4349-bc1e-abc00102c975/c7e3cca2-665e-4bc4-bcac-acc6011b9fa2/audio.mp3?utm_source=Podcast&in_playlist=4c18e072-24d2-4d60-9a42-abc00102c97e&t=1612652510")
+                        .url("https://omny.fm/shows/spiegel-update-die-nachrichten/07-02-die-wochenvorschau-lockdown-verl-ngerung-kri/embed")
                         .content_type("audio/mpeg")
                     )
                     .content(MediaContent::new()
@@ -785,4 +785,15 @@ fn test_subcategories() {
 
     let subcat = &category.subcategories[0];
     assert_eq!("Parenting", subcat.term.as_str());
+}
+
+// Verifies that 'media:content' elements without a URL are parsed via the child media:player info
+#[test]
+fn test_media_content_player() {
+    let test_data = test::fixture_as_string("rss2/rss_2.0_vimeo_media.xml");
+    let actual = parser::parse(test_data.as_bytes()).unwrap();
+
+    let entry = &actual.entries[0];
+    let content_url = entry.media[0].content[0].url.as_ref().unwrap();
+    assert_eq!("https://player.vimeo.com/video/1013595996?h=b1b80eff69", content_url.as_str());
 }


### PR DESCRIPTION
According to the spec https://www.rssboard.org/media-rss#media-content
> url should specify the direct URL to the media object. If not
> included, a <media:player> element must be specified.

This commit modifies the parser to look for a media:player child and takes the URL from that if present.

Fixes #242