### PR TITLE
Optional sanitization of content

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feed-rs"
-version = "2.2.0"
+version = "2.2.1"
 edition = '2021'
 authors = ["Mark Pritchard <mpritcha@gmail.com>"]
 include = [
@@ -22,6 +22,7 @@ readme = "README.md"
 travis-ci = { repository = "feed-rs/feed-rs", branch = "master" }
 
 [dependencies]
+ammonia = { version = "4", optional = true }
 chrono = { version = "0.4.38", features = ["serde"] }
 mediatype = { version = "0.19.18", features = ["serde"] }
 quick-xml = { version = "0.37.0", features = ["encoding"] }
@@ -31,3 +32,6 @@ serde_json = "1.0.133"
 siphasher = "1.0.1"
 url = { version = "2.5.3", features = ["serde"] }
 uuid = { version = "1.11.0", features = ["v4"] }
+
+[features]
+sanitize = ["dep:ammonia"]

--- a/feed-rs/README.md
+++ b/feed-rs/README.md
@@ -14,7 +14,17 @@ Add the dependency to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-feed-rs = "2.2.0"
+feed-rs = "2.2.1"
+```
+
+To automatically sanitize parsed HTML content, use the `sanitize` feature. Note
+that fields with a media type of `text/plain` will not be sanitized, to avoid
+potential data loss and should be sanitized by the consumer of the feed if
+rendered as HTML.
+
+```toml
+[dependencies]
+feed-rs = { version = "2.2.1", features = ["sanitize"] }
 ```
 
 ## Reading

--- a/feed-rs/src/parser/atom/mod.rs
+++ b/feed-rs/src/parser/atom/mod.rs
@@ -53,6 +53,12 @@ pub(crate) fn parse_feed<R: BufRead>(parser: &Parser, root: Element<R>) -> Parse
         }
     }
 
+    if parser.sanitize_content {
+        if let Some(t) = feed.description.as_mut() { t.sanitize() }
+        if let Some(t) = feed.rights.as_mut() { t.sanitize() }
+        if let Some(t) = feed.title.as_mut() { t.sanitize() }
+    }
+
     Ok(feed)
 }
 
@@ -229,6 +235,13 @@ fn handle_entry<R: BufRead>(parser: &Parser, element: Element<R>) -> ParseFeedRe
             // Nothing required for unknown elements
             _ => {}
         }
+    }
+
+    if parser.sanitize_content {
+        if let Some(c) = entry.content.as_mut() { c.sanitize() }
+        if let Some(t) = entry.rights.as_mut() { t.sanitize() }
+        if let Some(t) = entry.summary.as_mut() { t.sanitize() }
+        if let Some(t) = entry.title.as_mut() { t.sanitize() }
     }
 
     // If a media:content or media:thumbnail item was found in this entry, then attach it

--- a/feed-rs/src/parser/atom/tests.rs
+++ b/feed-rs/src/parser/atom/tests.rs
@@ -105,9 +105,11 @@ fn test_example_2() {
 // Real-life example from Akamai (includes categories and elements from a different namespace, along with locally declared namespaces on atom 1.0 elements)
 #[test]
 fn test_example_3() {
-    // Parse the feed
+    // Parse the feed; note that the result with sanitization active differs from the expected,
+    // so we will explicitly disable sanitization for this test.
     let test_data = test::fixture_as_string("atom/atom_example_3.xml");
-    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    let p = parser::Builder::new().sanitize_content(false).build();
+    let actual = p.parse(test_data.as_bytes()).unwrap();
 
     let expected = Feed::new(FeedType::Atom)
         .title(Text::new("The Akamai Blog".into()))
@@ -155,9 +157,11 @@ fn test_example_3() {
 // Real-life example from ebmpapst (CDATA text elements, unusual category representation)
 #[test]
 fn test_example_4() {
-    // Parse the feed
+    // Parse the feed; note that the result with sanitization active differs from the expected,
+    // so we will explicitly disable sanitization for this test.
     let test_data = test::fixture_as_string("atom/atom_example_4.xml");
-    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    let p = parser::Builder::new().sanitize_content(false).build();
+    let actual = p.parse(test_data.as_bytes()).unwrap();
 
     let expected = Feed::new(FeedType::Atom)
         .author(Person::new("ebm-papst"))
@@ -183,9 +187,11 @@ fn test_example_4() {
 // Real-life example from USGS (CDATA, different namespaces)
 #[test]
 fn test_example_5() {
-    // Parse the feed
+    // Parse the feed; note that the result with sanitization active differs from the expected,
+    // so we will explicitly disable sanitization for this test.
     let test_data = test::fixture_as_string("atom/atom_example_5.xml");
-    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    let p = parser::Builder::new().sanitize_content(false).build();
+    let actual = p.parse(test_data.as_bytes()).unwrap();
 
     let expected = Feed::new(FeedType::Atom)
         .title(Text::new("USGS Magnitude 2.5+ Earthquakes, Past Hour".into()))
@@ -347,9 +353,11 @@ fn test_example_6() {
 #[test]
 fn test_example_7() {
     let expected_body = r#"<div xmlns="http://www.w3.org/1999/xhtml"><p>This is a follow up from <a href="https://who-t.blogspot.com/2018/12/high-resolution-wheel-scrolling-on.html">the kernel support for high-resolution wheel scrolling</a> which you totally forgot about because it's already more then a year in the past and seriously, who has the attention span these days to remember this. Anyway, I finally found time and motivation to pick this up again and I started lining up the pieces like cans, for it only to be shot down by the commentary of strangers on the internet. The <a href="https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/72">Wayland merge request</a> lists the various pieces (libinput, wayland, weston, mutter, gtk and Xwayland) but for the impatient there's also an <a href="https://copr.fedorainfracloud.org/coprs/whot/high-resolution-wheel-scrolling/">Fedora 32 COPR</a>. For all you weirdos inexplicably not running the latest Fedora, well, you'll have to compile this yourself, just like I did. </p> <p>Let's recap: in v5.0 the kernel added new axes <b>REL_WHEEL_HI_RES</b> and <b>REL_HWHEEL_HI_RES</b> for all devices. On devices that actually support high-resolution wheel scrolling (Logitech and Microsoft mice, primarily) you'll get multiple hires events before the now-legacy <b>REL_WHEEL</b> events. On all other devices those two are in sync. </p> <p>Integrating this into the userspace stack was a bit of a mess at first, but I think the solution is good enough, even if it has a rather verbose explanation on how to handle it. The actual patches to integrate ended up being relatively simple. So let's see why it's a bit weird: </p> <p>When Wayland started, back in WhoahReallyThatLongAgo, scrolling was specified as the <b>wl_pointer.axis</b> event with a value in pixels. This works fine for touchpads, not so much for wheels. The early versions of Weston decreed that one wheel click was 10 pixels [1] and, perhaps surprisingly, the world kept on turning. When libinput was forked from Weston <a href="https://who-t.blogspot.com/2015/01/providing-physical-movement-of-wheel.html">an early change</a> was that wheel events would have two values - degrees of movement and click count ("discrete steps"). The wayland protocol was expanded to include the discrete steps as <b>wl_pointer.axis_discrete</b> as well. Then backwards compatibility reared its ugly head and Mutter, Weston, GTK all basically said: one discrete step equals 10 pixels so we multiply the discrete value by 10 and, perhaps surprisingly, the world kept on turning. </p> <p>This worked out well enough for a few years but with high resolution wheels we ran into a problem. Discrete steps are integers, so we can't send partial values. And the protocol is defined in a way that any tweaking of the behaviour would result in broken clients which, perhaps surprisingly, is a Bad Thing. This lead to the current proposal of separate events. <b>LIBINPUT_EVENT_POINTER_AXIS_WHEEL</b> and for Wayland the <b>wl_pointer.axis_v120</b> event, linked to above. These events are (like the kernel events) a parallel event stream to the previous events and effectively replace the <b>LIBINPUT_EVENT_POINTER_AXIS</b> and Wayland <b>wl_pointer.axis/axis_discrete</b> pair for wheel events (not so for touchpad or button scrolling though). </p> <p>The compositor side of things is relatively simple: take the events from libinput and pass the hires ones as v120 events and the lowres ones as v120 events with a value of zero. The client side takes the v120 events and uses them over <b>wl_pointer.axis/axis_discrete</b> unless one is zero in which case you can discard all axis events in that <b>wl_pointer.frame</b>. Since most client implementation already have the support for smooth scrolling (because, well, touchpads do exist) it's relatively simple to integrate - the new events just feed into the smooth scrolling code. And since you already have to do wheel emulation for that (because, well, old clients exist) wheel emulation is handled easily too. </p> <p>All that to provide buttery smooth [2] wheel scrolling. Or not, if your hardware doesn't support it. In which case, well, live with the warm fuzzy feeling that someone else has a better user experience now. Or soon, anyway. </p> <p><small>[1] with, I suspect, the scientific measurement of "yeah, that seems about alright"<br></br>[2] like butter out of a fridge, so still chunky but at least less so than before<br></br></small></p></div>"#;
-    // Parse the feed
+    // Parse the feed; note that the result with sanitization active differs from the expected,
+    // so we will explicitly disable sanitization for this test.
     let test_data = test::fixture_as_string("atom/atom_example_7.xml");
-    let feed = parser::parse(test_data.as_bytes()).unwrap();
+    let p = parser::Builder::new().sanitize_content(false).build();
+    let feed = p.parse(test_data.as_bytes()).unwrap();
     let body = feed
         .entries
         .first()

--- a/feed-rs/src/parser/json/mod.rs
+++ b/feed-rs/src/parser/json/mod.rs
@@ -150,6 +150,13 @@ fn handle_item(parser: &Parser, ji: JsonItem) -> Entry {
         attachments.into_iter().map(handle_attachment).for_each(|link| entry.links.push(link))
     });
 
+    // Per the JSON Feed spec, "the only place HTML is allowed in this format is in content_html";
+    // as such when sanitizing, we will *only* inspect entry.content.
+    // it's "text/html".
+    if parser.sanitize_content {
+        if let Some(c) = entry.content.as_mut() { c.sanitize() }
+    }
+
     entry
 }
 

--- a/feed-rs/src/parser/json/tests.rs
+++ b/feed-rs/src/parser/json/tests.rs
@@ -52,9 +52,11 @@ fn test_example_1() {
 // Verify we can parse the specification example
 #[test]
 fn test_spec_1() {
-    // Parse the feed
+    // Parse the feed; note that the result with sanitization active differs from the expected,
+    // so we will explicitly disable sanitization for this test.
     let test_data = test::fixture_as_string("jsonfeed/jsonfeed_spec_1.json");
-    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    let p = parser::Builder::new().sanitize_content(false).build();
+    let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
     let expected = Feed::new(FeedType::JSON)

--- a/feed-rs/src/parser/mod.rs
+++ b/feed-rs/src/parser/mod.rs
@@ -105,6 +105,7 @@ impl fmt::Display for ParseErrorKind {
 pub struct Parser {
     base_uri: Option<String>,
     id_generator: Box<IdGenerator>,
+    sanitize_content: bool,
     timestamp_parser: Box<TimestampParser>,
 }
 
@@ -222,6 +223,7 @@ pub fn parse<R: Read>(source: R) -> ParseFeedResult<model::Feed> {
 pub struct Builder {
     base_uri: Option<String>,
     id_generator: Box<IdGenerator>,
+    sanitize_content: bool,
     timestamp_parser: Box<TimestampParser>,
 }
 
@@ -242,6 +244,7 @@ impl Builder {
         Parser {
             base_uri: self.base_uri,
             id_generator: self.id_generator,
+            sanitize_content: self.sanitize_content,
             timestamp_parser: self.timestamp_parser,
         }
     }
@@ -273,6 +276,13 @@ impl Builder {
         })
     }
 
+    /// Registers the flag for sanitizing content when the "sanitize" feature
+    /// is available
+    pub fn sanitize_content(mut self, flag: bool) -> Self {
+        self.sanitize_content = flag;
+        self
+    }
+
     /// Registers a custom timestamp parser
     pub fn timestamp_parser<F>(mut self, ts_parser: F) -> Self
     where
@@ -289,6 +299,7 @@ impl Default for Builder {
         Builder {
             base_uri: None,
             id_generator: Box::new(generate_id),
+            sanitize_content: true,
             timestamp_parser: Box::new(util::parse_timestamp_lenient),
         }
     }

--- a/feed-rs/src/parser/rss0/tests.rs
+++ b/feed-rs/src/parser/rss0/tests.rs
@@ -84,9 +84,11 @@ fn test_0_91_missing_id() {
 // Trimmed example of RSS 0.92 from the specification at http://backend.userland.com/rss092
 #[test]
 fn test_0_92_spec_1() {
-    // Parse the feed
+    // Parse the feed; note that the result with sanitization active differs from the expected,
+    // so we will explicitly disable sanitization for this test.
     let test_data = test::fixture_as_string("rss0/rss_0.92_spec_1.xml");
-    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    let p = parser::Builder::new().sanitize_content(false).build();
+    let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
     let entry0 = actual.entries.first().unwrap();

--- a/feed-rs/src/parser/rss1/mod.rs
+++ b/feed-rs/src/parser/rss1/mod.rs
@@ -53,6 +53,12 @@ fn handle_channel<R: BufRead>(parser: &Parser, feed: &mut Feed, channel: Element
         }
     }
 
+    if parser.sanitize_content {
+        if let Some(t) = feed.description.as_mut() { t.sanitize() }
+        if let Some(t) = feed.rights.as_mut() { t.sanitize() }
+        if let Some(t) = feed.title.as_mut() { t.sanitize() }
+    }
+
     Ok(())
 }
 
@@ -89,6 +95,7 @@ fn handle_item<R: BufRead>(parser: &Parser, element: Element<R>) -> ParseFeedRes
 
     for child in element.children() {
         let child = child?;
+        println!("{:?}", child.ns_and_tag());
         match child.ns_and_tag() {
             (NS::RSS, "title") => entry.title = util::handle_text(child),
 
@@ -125,6 +132,13 @@ fn handle_item<R: BufRead>(parser: &Parser, element: Element<R>) -> ParseFeedRes
                 src: ce.src.map(|s| Link::new(s, element.xml_base.as_ref())),
             });
         }
+    }
+
+    if parser.sanitize_content {
+        if let Some(c) = entry.content.as_mut() { c.sanitize() }
+        if let Some(t) = entry.rights.as_mut() { t.sanitize() }
+        if let Some(t) = entry.summary.as_mut() { t.sanitize() }
+        if let Some(t) = entry.title.as_mut() { t.sanitize() }
     }
 
     // If we found at least 1 link

--- a/feed-rs/src/parser/rss2/mod.rs
+++ b/feed-rs/src/parser/rss2/mod.rs
@@ -73,6 +73,12 @@ fn handle_channel<R: BufRead>(parser: &Parser, channel: Element<R>) -> ParseFeed
         }
     }
 
+    if parser.sanitize_content {
+        if let Some(t) = feed.description.as_mut() { t.sanitize() }
+        if let Some(t) = feed.rights.as_mut() { t.sanitize() }
+        if let Some(t) = feed.title.as_mut() { t.sanitize() }
+    }
+
     Ok(feed)
 }
 
@@ -242,6 +248,13 @@ fn handle_item<R: BufRead>(parser: &Parser, element: Element<R>) -> ParseFeedRes
             // Nothing required for unknown elements
             _ => {}
         }
+    }
+
+    if parser.sanitize_content {
+        if let Some(c) = entry.content.as_mut() { c.sanitize() }
+        if let Some(t) = entry.rights.as_mut() { t.sanitize() }
+        if let Some(t) = entry.summary.as_mut() { t.sanitize() }
+        if let Some(t) = entry.title.as_mut() { t.sanitize() }
     }
 
     // If a media:content item with content exists, then emit it

--- a/feed-rs/src/parser/rss2/tests.rs
+++ b/feed-rs/src/parser/rss2/tests.rs
@@ -120,9 +120,11 @@ fn test_example_3() {
 // Structured event data on earthquakes
 #[test]
 fn test_example_4() {
-    // Parse the feed
+    // Parse the feed; note that the result with sanitization active differs from the expected,
+    // so we will explicitly disable sanitization for this test.
     let test_data = test::fixture_as_string("rss2/rss_2.0_example_4.xml");
-    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    let p = parser::Builder::new().sanitize_content(false).build();
+    let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
     let expected = Feed::new(FeedType::RSS2)
@@ -215,9 +217,11 @@ fn test_example_5() {
 // Trailers from Apple (no UUID)
 #[test]
 fn test_example_6() {
-    // Parse the feed
+    // Parse the feed; note that the result with sanitization active differs from the expected,
+    // so we will explicitly disable sanitization for this test.
     let test_data = test::fixture_as_string("rss2/rss_2.0_example_6.xml");
-    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    let p = parser::Builder::new().sanitize_content(false).build();
+    let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
     let expected = Feed::new(FeedType::RSS2)
@@ -260,9 +264,11 @@ fn test_wirecutter() {
 // Verify we can parse the example contained in the RSS 2.0 specification
 #[test]
 fn test_spec_1() {
-    // Parse the feed
+    // Parse the feed; note that the result with sanitization active differs from the expected,
+    // so we will explicitly disable sanitization for this test.
     let test_data = test::fixture_as_string("rss2/rss_2.0_spec_1.xml");
-    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    let p = parser::Builder::new().sanitize_content(false).build();
+    let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
     let expected = Feed::new(FeedType::RSS2)
@@ -352,9 +358,11 @@ fn test_rockpapershotgun() {
 // Verifies that we can handle mixed MediaRSS and itunes/enclosure
 #[test]
 fn test_spiegel() {
-    // Parse the feed
+    // Parse the feed; note that the result with sanitization active differs from the expected,
+    // so we will explicitly disable sanitization for this test.
     let test_data = test::fixture_as_string("rss2/rss_2.0_spiegel.xml");
-    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    let p = parser::Builder::new().sanitize_content(false).build();
+    let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
     let expected = Feed::new(FeedType::RSS2)
@@ -496,9 +504,11 @@ fn test_bbc() {
 // Verifies that we can handle mixed MediaRSS and itunes/enclosure
 #[test]
 fn test_ch9() {
-    // Parse the feed
+    // Parse the feed; note that the result with sanitization active differs from the expected,
+    // so we will explicitly disable sanitization for this test.
     let test_data = test::fixture_as_string("rss2/rss_2.0_ch9.xml");
-    let actual = parser::parse(test_data.as_bytes()).unwrap();
+    let p = parser::Builder::new().sanitize_content(false).build();
+    let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
     let expected = Feed::new(FeedType::RSS2)

--- a/feed-rs/src/parser/tests.rs
+++ b/feed-rs/src/parser/tests.rs
@@ -38,7 +38,7 @@ fn serde_regression() {
     find_fixture_files(&fixture_root_dir, |source_path, json_path| {
         // Parse the original fixture file
         let data = fs::read(&source_path).unwrap();
-        let parser = parser::Builder::new().build();
+        let parser = parser::Builder::default().sanitize_content(false).build();
         let mut feed = parser.parse(data.as_slice()).unwrap();
 
         // Parse the previously serialised form

--- a/feed-rs/tests/sanitize.rs
+++ b/feed-rs/tests/sanitize.rs
@@ -1,0 +1,245 @@
+#[allow(unused_imports)]
+use feed_rs::parser;
+
+// Bad input adapted from Python's feedparser library: https://github.com/kurtmckee/feedparser
+
+#[test]
+#[cfg(feature = "sanitize")]
+fn test_sanitize_atom_plain_text() {
+    let source = r#"
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+
+  <title><![CDATA[<script>title</script>]]></title>
+  <subtitle><![CDATA[<script>subtitle</script>]]></subtitle>
+  <link href="http://example.org/"/>
+  <updated>2003-12-13T18:30:02Z</updated>
+  <author>
+    <name>Erika &lt;tag /&gt; Mustermann</name>
+  </author>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+
+  <entry>
+    <title type="text">&lt;script&gt;alert('xyzzy');&lt;/script&gt;title</title>
+    <link href="http://example.org/2003/12/13/atom03"/>
+    <content><p style="background-color: black;">Sphinx of black quartz, hear my vow!</p><style>p { color: white; }</style></content>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+  </entry>
+
+</feed>
+    "#;
+    let feed = parser::parse(source.as_bytes()).unwrap();
+    // Explicit plain/text
+    let feed_title = feed.title.unwrap();
+    // Implicit plain/text
+    let feed_description = feed.description.unwrap();
+    // No HTML supported
+    let feed_author = feed.authors[0].clone();
+
+    let entry = feed.entries[0].clone();
+    // Explicit plain text
+    let entry_title = entry.title.unwrap();
+    // Implicit plain text
+    let entry_content = entry.content.unwrap();
+
+    assert_eq!(feed_description.content, r#"<script>subtitle</script>"#);
+    assert_eq!(feed_description.content_type.as_str(), "text/plain");
+    assert_eq!(feed_title.content, r#"<script>title</script>"#);
+    assert_eq!(feed_title.content_type.as_str(), "text/plain");
+    assert_eq!(feed_author.name, r#"Erika <tag /> Mustermann"#);
+
+    assert_eq!(entry_title.content, "<script>alert('xyzzy');</script>title");
+    assert_eq!(entry_title.content_type.as_str(), "text/plain");
+    assert_eq!(
+        entry_content.body.unwrap(),
+        r#"<p style="background-color: black;">Sphinx of black quartz, hear my vow!</p><style>p { color: white; }</style>"#
+    );
+    assert_eq!(entry_content.content_type.as_str(), "text/plain");
+}
+
+#[test]
+#[cfg(feature = "sanitize")]
+fn test_sanitize_atom() {
+    let source = r#"
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+
+  <title type="text/html" mode="escaped">&lt;img src="http://www.ragingplatypus.com/i/cam-full.jpg" onkeydown="location.href='http://www.ragingplatypus.com/';" /></title>
+  <subtitle type="text/html"><div><faketag /><fake>Safe</fake> subtitle</div></subtitle>
+  <link href="http://example.org/"/>
+  <updated>2003-12-13T18:30:02Z</updated>
+  <author>
+    <name>Erika Mustermann</name>
+  </author>
+  <id>urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6</id>
+  <rights type="text/html" mode="escaped">
+&lt;!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+&lt;html xmlns="http://www.w3.org/1999/xhtml">
+&lt;head>
+&lt;title>Crazy&lt;/title>
+&lt;/head>
+&lt;body    notRealAttribute="value"onload="executeMe();"foo="bar"
+
+>
+&lt;/body>
+
+&lt;/html>
+  </rights>
+
+  <entry>
+    <title type="text/html" mode="escaped"><a href="http://example.com">Safe&lt;iframe src="http://www.example.com/">&lt;/iframe> title</a></title>
+    <link href="http://example.org/2003/12/13/atom03"/>
+    <content type="text/html"><p style="background-color: black;">Sphinx of black quartz, hear my vow!</p><style>p { color: white; }</style></content>
+    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+    <updated>2003-12-13T18:30:02Z</updated>
+    <summary type="text/html">Safe&lt;script type="text/javascript">location.href='http:/'+'/example.com/';&lt;/script> summary.</summary>
+  </entry>
+
+</feed>
+    "#;
+    let feed = parser::parse(source.as_bytes()).unwrap();
+    let feed_title = feed.title.unwrap();
+    let feed_description = feed.description.unwrap();
+    let feed_rights = feed.rights.unwrap();
+
+    let entry = feed.entries[0].clone();
+    let entry_title = entry.title.unwrap();
+    let entry_summary = entry.summary.unwrap();
+    let entry_content = entry.content.unwrap();
+
+    assert_eq!(feed_title.content, r#"<img src="http://www.ragingplatypus.com/i/cam-full.jpg">"#);
+    assert_eq!(feed_title.content_type.as_str(), "text/html");
+    assert_eq!(feed_description.content, r#"<div>Safe subtitle</div>"#);
+    assert_eq!(feed_description.content_type.as_str(), "text/html");
+    assert_eq!(feed_rights.content, "\n\n\n\nCrazy\n\n\n\n\n");
+    assert_eq!(feed_description.content_type.as_str(), "text/html");
+
+    // noopener/noreferrer inserted by ammonia
+    assert_eq!(entry_title.content, r#"<a href="http://example.com" rel="noopener noreferrer">Safe title</a>"#);
+    assert_eq!(entry_title.content_type.as_str(), "text/html");
+    assert_eq!(entry_summary.content, "Safe summary.");
+    assert_eq!(entry_summary.content_type.as_str(), "text/html");
+    assert_eq!(entry_content.body.unwrap(), "<p>Sphinx of black quartz, hear my vow!</p>");
+    assert_eq!(entry_content.content_type.as_str(), "text/html");
+}
+
+#[test]
+#[cfg(feature = "sanitize")]
+fn test_sanitize_rss2() {
+    let source = r#"
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+>
+  <channel>
+  <title>2 &gt; 1 &lt;img src="http://www.ragingplatypus.com/i/cam-full.jpg" onkeydown="location.href='http://www.ragingplatypus.com/';" /></title>
+  <link href="http://example.org/"/>
+  <item>
+    <title>Safe&lt;iframe src="http://www.example.com/">&lt;/iframe> title</title>
+    <content:encoded><![CDATA[<p onclick="alert('xyzzy');">Safe <a href="http://example.com/">content</a></p>]]></content:encoded>
+    <description>safe&lt;link rel="stylesheet" type="text/css" href="http://example.com/evil.css"> summary</description>
+  </item>
+  </channel>
+</rss>
+    "#;
+    let feed = parser::parse(source.as_bytes()).unwrap();
+    let feed_title = feed.title.unwrap();
+
+    let entry = feed.entries[0].clone();
+    let entry_title = entry.title.unwrap();
+    let entry_summary = entry.summary.unwrap();
+    let entry_content = entry.content.unwrap();
+
+    /* DANGER ZONE: text/plain is not escaped! */
+    assert_eq!(
+        feed_title.content,
+        r#"2 > 1 <img src="http://www.ragingplatypus.com/i/cam-full.jpg" onkeydown="location.href='http://www.ragingplatypus.com/';" />"#
+    );
+    assert_eq!(feed_title.content_type.as_str(), "text/plain");
+    assert_eq!(entry_title.content, r#"Safe<iframe src="http://www.example.com/"></iframe> title"#);
+    assert_eq!(entry_title.content_type.as_str(), "text/plain");
+
+    assert_eq!(entry_summary.content, r#"safe summary"#);
+    assert_eq!(entry_summary.content_type.as_str(), "text/html");
+
+    // noopener/noreferrer inserted by ammonia
+    assert_eq!(
+        entry_content.body.unwrap(),
+        r#"<p>Safe <a href="http://example.com/" rel="noopener noreferrer">content</a></p>"#
+    );
+    assert_eq!(entry_content.content_type.as_str(), "text/html");
+}
+
+#[test]
+#[cfg(feature = "sanitize")]
+fn test_sanitize_rss1() {
+    let source = r#"
+<rdf:RDF
+    xmlns="http://purl.org/rss/1.0/"
+    xmlns:content="http://purl.org/rss/1.0/modules/content/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+>
+<channel rdf:about="http://example.com/index.rdf">
+<title>&lt;example feed&gt;</title>
+</channel>
+<item>
+  <title><![CDATA[<example title>]]></title>
+  <link>http://example.com/1</link>
+  <dc:description>&lt;example description&gt;</dc:description>
+  <content:encoded>&lt;p style="background-color: black;"&gt;Sphinx of black quartz, hear my vow!&lt;/p&gt;&lt;style&gt;p { color: white; }&lt;/style&gt;&lt;/content&gt;</content:encoded>
+</item>
+</rdf:RDF>
+"#;
+    let feed = parser::parse(source.as_bytes()).unwrap();
+    println!("{:?}", &feed);
+    let feed_title = feed.title.unwrap();
+
+    let entry = feed.entries[0].clone();
+    let entry_title = entry.title.unwrap();
+    let entry_summary = entry.summary.unwrap();
+    let entry_content = entry.content.unwrap();
+
+    /* DANGER ZONE: text/plain is not escaped! */
+    assert_eq!(feed_title.content, "<example feed>");
+    assert_eq!(feed_title.content_type.as_str(), "text/plain");
+    assert_eq!(entry_title.content, "<example title>");
+    assert_eq!(entry_title.content_type.as_str(), "text/plain");
+    assert_eq!(entry_summary.content, "<example description>");
+    assert_eq!(entry_summary.content_type.as_str(), "text/plain");
+
+    assert_eq!(entry_content.body.unwrap(), "<p>Sphinx of black quartz, hear my vow!</p>");
+    assert_eq!(entry_content.content_type.as_str(), "text/html");
+}
+
+#[test]
+#[cfg(feature = "sanitize")]
+fn test_sanitize_json() {
+    let source = r#"
+{
+    "version": "https://jsonfeed.org/version/1.1",
+    "title": "My Example Feed",
+    "home_page_url": "https://example.org/",
+    "feed_url": "https://example.org/feed.json",
+    "items": [
+        {
+            "id": "1",
+            "content_text": "<script>alert(\"xyzzy\")</script>",
+            "content_html": "<script>alert(\"xyzzy\")</script><p>Hello, world!</p>",
+            "url": "https://example.org/initial-post"
+        }
+    ]
+}"#;
+    let feed = parser::parse(source.as_bytes()).unwrap();
+    println!("{:?}", &feed);
+
+    let entry = feed.entries[0].clone();
+    let entry_summary = entry.summary.unwrap();
+    let entry_content = entry.content.unwrap();
+
+    assert_eq!(entry_summary.content, r#"<script>alert("xyzzy")</script>"#);
+    assert_eq!(entry_summary.content_type.as_str(), "text/plain");
+    assert_eq!(entry_content.body.unwrap(), "<p>Hello, world!</p>");
+    assert_eq!(entry_content.content_type.as_str(), "text/html");
+}


### PR DESCRIPTION
This changeset introduces a new feature, "sanitize", which uses the `ammonia` sanitization library to remove a number of potentially risky tags and attributes from parsed content. Feed description, rights, and title values and entry content, rights, summary, and title values will be sanitized when this feature is active.