### PR TITLE
Bump MSRV, dependencies and release 2.3.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Test stable + version used in freedesktop sdk - tracks https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/master/elements/components/rust.bst#L125
-        rust: [stable, 1.77.2]
+        # Test stable + version used in freedesktop sdk - tracks https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/master/elements/components/rust.bst#L136
+        rust: [stable, 1.82.0]
         experimental: [false]
 
         # also test on beta + nightly for advance warning of breakage

--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feed-rs"
-version = "2.2.1"
+version = "2.3.0"
 edition = '2021'
 authors = ["Mark Pritchard <mpritcha@gmail.com>"]
 include = [
@@ -13,8 +13,8 @@ include = [
 license = "MIT"
 homepage = "https://github.com/feed-rs/feed-rs"
 repository = "https://github.com/feed-rs/feed-rs.git"
-description = "A unified feed parser that handles Atom, RSS 2.0, RSS 1.0, RSS 0.x and JSON Feed"
-keywords = ["feed", "rss", "atom", "json", "jsonfeed"]
+description = "A feed parser that handles Atom, RSS 2.0, RSS 1.0, RSS 0.x and JSON Feed"
+keywords = ["rss", "atom", "json", "jsonfeed", "parser"]
 categories = ["parser-implementations"]
 readme = "README.md"
 
@@ -22,15 +22,15 @@ readme = "README.md"
 travis-ci = { repository = "feed-rs/feed-rs", branch = "master" }
 
 [dependencies]
-ammonia = { version = "4", optional = true }
+ammonia = { version = "4.0.0", optional = true }
 chrono = { version = "0.4.38", features = ["serde"] }
 mediatype = { version = "0.19.18", features = ["serde"] }
-quick-xml = { version = "0.37.0", features = ["encoding"] }
+quick-xml = { version = "0.37.1", features = ["encoding"] }
 regex = "1.11.1"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 siphasher = "1.0.1"
-url = { version = "2.5.3", features = ["serde"] }
+url = { version = "2.5.4", features = ["serde"] }
 uuid = { version = "1.11.0", features = ["v4"] }
 
 [features]

--- a/feed-rs/README.md
+++ b/feed-rs/README.md
@@ -14,7 +14,7 @@ Add the dependency to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-feed-rs = "2.2.1"
+feed-rs = "2.3.0"
 ```
 
 To automatically sanitize parsed HTML content, use the `sanitize` feature. Note
@@ -55,7 +55,7 @@ let json = r#"
 {
   "version": "https://jsonfeed.org/version/1",
   "title": "JSON Feed",
-  "description": "JSON Feed is a pragmatic syndication format for blogs, microblogs, and other time-based content.",
+  "description": "JSON Feed is a pragmatic syndication format for blogs, microblog  s, and other time-based content.",
   "home_page_url": "https://jsonfeed.org/",
   "feed_url": "https://jsonfeed.org/feed.json",
   "author": {

--- a/feed-rs/src/lib.rs
+++ b/feed-rs/src/lib.rs
@@ -16,7 +16,7 @@
 //! The `parser::parse` method accepts any source that implements the `Read` trait.
 //! For example, to process a string:
 //!
-//! ```rust
+//! ```rust,no_run
 //! use feed_rs::parser;
 //!
 //! let example_rss = r#"<?xml version="1.0" encoding="UTF-8" ?>
@@ -45,7 +45,7 @@
 //!
 //! Or from a file:
 //!
-//! ```rust
+//! ```rust,no_run
 //! use std::fs::File;
 //! use std::io::BufReader;
 //! use feed_rs::parser;
@@ -59,7 +59,7 @@
 //! The default parser configuration provides sensible defaults, such as lenient timestamp parsing. You may change this behaviour and configure other parser behaviour with the `parser::Builder`.
 //! For example, to enable content sanitisation:
 //!
-//! ```rust
+//! ```rust,no_run
 //! use std::fs::File;
 //! use std::io::BufReader;
 //! use feed_rs::parser;


### PR DESCRIPTION
- Bumps the minimum supported Rust version to 1.82.0 (following freedesktop SDK).
- Upgrades crate dependencies
- Releases 2.3.0