### PR TITLE
Remove debug print in rss1 parser

### DIFF
--- a/feed-rs/src/parser/rss1/mod.rs
+++ b/feed-rs/src/parser/rss1/mod.rs
@@ -101,7 +101,6 @@ fn handle_item<R: BufRead>(parser: &Parser, element: Element<R>) -> ParseFeedRes
 
     for child in element.children() {
         let child = child?;
-        println!("{:?}", child.ns_and_tag());
         match child.ns_and_tag() {
             (NS::RSS, "title") => entry.title = util::handle_text(child),
 


### PR DESCRIPTION
This `println!()` was added in 9b55e3510453d48608e27e3f45398c7990b2802e 

I'm guessing it was a debug print that accidentally got submitted. It's a bit odd to have a library printing to stdout.