### PR TITLE
derive Default for Feed, Entry

### DIFF
--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -32,7 +32,7 @@ use crate::parser::util::parse_timestamp_lenient;
 ///     * item - comments (link to comments on the article), source (pointer to the channel, but our data model links items to a channel)
 ///   * RSS 1:
 ///     * channel - rdf:about attribute (pointer to feed), textinput (text box e.g. for search)
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Feed {
     /// Type of this feed (e.g. RSS2, Atom etc)
     pub feed_type: FeedType,
@@ -104,31 +104,6 @@ pub struct Feed {
     /// * Atom (optional): Individual entries within the feed (e.g. a blog post)
     /// * RSS 1+2 (optional): Individual items within the channel.
     pub entries: Vec<Entry>,
-}
-
-impl Feed {
-    pub(crate) fn new(feed_type: FeedType) -> Self {
-        Feed {
-            feed_type,
-            id: "".into(),
-            title: None,
-            updated: None,
-            authors: Vec::new(),
-            description: None,
-            links: Vec::new(),
-            categories: Vec::new(),
-            contributors: Vec::new(),
-            generator: None,
-            icon: None,
-            language: None,
-            logo: None,
-            published: None,
-            rating: None,
-            rights: None,
-            ttl: None,
-            entries: Vec::new(),
-        }
-    }
 }
 
 #[cfg(test)]
@@ -220,8 +195,9 @@ impl Feed {
 }
 
 /// Type of a feed (RSS, Atom etc)
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub enum FeedType {
+    #[default]
     Atom,
     JSON,
     RSS0,
@@ -230,7 +206,7 @@ pub enum FeedType {
 }
 
 /// An item within a feed
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Entry {
     /// A unique identifier for this item with a feed. If not supplied it is initialised to a hash of the first link or a UUID if not available.
     /// * Atom (required): Identifies the entry using a universally unique and permanent URI.
@@ -304,28 +280,6 @@ pub struct Entry {
     /// Atom (optional): The base url specified on the item to resolve any relative
     /// references found within the scope on the item
     pub base: Option<String>,
-}
-
-impl Default for Entry {
-    fn default() -> Self {
-        Entry {
-            id: "".into(),
-            title: None,
-            updated: None,
-            authors: Vec::new(),
-            content: None,
-            links: Vec::new(),
-            summary: None,
-            categories: Vec::new(),
-            contributors: Vec::new(),
-            published: None,
-            source: None,
-            rights: None,
-            media: Vec::new(),
-            language: None,
-            base: None,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/feed-rs/src/parser/atom/mod.rs
+++ b/feed-rs/src/parser/atom/mod.rs
@@ -2,7 +2,7 @@ use std::io::BufRead;
 
 use mediatype::{names, MediaTypeBuf};
 
-use crate::model::{Category, Content, Entry, Feed, FeedType, Generator, Image, Link, MediaObject, Person, Text};
+use crate::model::{Category, Content, Entry, Feed, Generator, Image, Link, MediaObject, Person, Text};
 use crate::parser::mediarss::handle_media_element;
 use crate::parser::util;
 use crate::parser::util::if_some_then;
@@ -15,9 +15,10 @@ mod tests;
 
 /// Parses an Atom feed into our model
 pub(crate) fn parse_feed<R: BufRead>(parser: &Parser, root: Element<R>) -> ParseFeedResult<Feed> {
-    let mut feed = Feed::new(FeedType::Atom);
-
-    feed.language = util::handle_language_attr(&root);
+    let mut feed = Feed {
+        language: util::handle_language_attr(&root),
+        ..Feed::default()
+    };
 
     for child in root.children() {
         let child = child?;
@@ -72,7 +73,7 @@ pub(crate) fn parse_feed<R: BufRead>(parser: &Parser, root: Element<R>) -> Parse
 ///
 /// Note that the entry is wrapped in an empty Feed to keep the API consistent
 pub(crate) fn parse_entry<R: BufRead>(parser: &Parser, root: Element<R>) -> ParseFeedResult<Feed> {
-    let mut feed = Feed::new(FeedType::Atom);
+    let mut feed = Feed::default();
 
     if_some_then(handle_entry(parser, root)?, |entry| feed.entries.push(entry));
 

--- a/feed-rs/src/parser/atom/tests.rs
+++ b/feed-rs/src/parser/atom/tests.rs
@@ -1,5 +1,5 @@
 use crate::model::{
-    Category, Content, Entry, Feed, FeedType, Generator, Image, Link, MediaCommunity, MediaContent, MediaObject, MediaText, MediaThumbnail, Person, Text,
+    Category, Content, Entry, Feed, Generator, Image, Link, MediaCommunity, MediaContent, MediaObject, MediaText, MediaThumbnail, Person, Text,
 };
 use crate::parser;
 use crate::util::test;
@@ -12,7 +12,7 @@ fn test_example_1() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::Atom)
+    let expected = Feed::default()
         .title(Text::new("dive into mark".into()))
         .description(Text::new("A <em>lot</em> of effort\n        went into making this effortless".into()).content_type("text/html"))
         .updated_parsed("2005-07-31T12:29:29Z")
@@ -55,7 +55,7 @@ fn test_example_2() {
     let test_data = test::fixture_as_string("atom/atom_example_2.xml");
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
-    let expected = Feed::new(FeedType::Atom)
+    let expected = Feed::default()
         .id("tag:theregister.co.uk,2005:feed/theregister.co.uk/science/")
         .language("en")
         .title(Text::new("The Register - Science".into()))
@@ -111,7 +111,7 @@ fn test_example_3() {
     let p = parser::Builder::new().sanitize_content(false).build();
     let actual = p.parse(test_data.as_bytes()).unwrap();
 
-    let expected = Feed::new(FeedType::Atom)
+    let expected = Feed::default()
         .title(Text::new("The Akamai Blog".into()))
         .link(Link::new("https://blogs.akamai.com/", None)
             .rel("alternate")
@@ -163,7 +163,7 @@ fn test_example_4() {
     let p = parser::Builder::new().sanitize_content(false).build();
     let actual = p.parse(test_data.as_bytes()).unwrap();
 
-    let expected = Feed::new(FeedType::Atom)
+    let expected = Feed::default()
         .author(Person::new("ebm-papst"))
         .link(Link::new("http://www.ebmpapst.com/en/ebmpapst_productnews_atom_feed.xml", None)
             .rel("self")
@@ -193,7 +193,7 @@ fn test_example_5() {
     let p = parser::Builder::new().sanitize_content(false).build();
     let actual = p.parse(test_data.as_bytes()).unwrap();
 
-    let expected = Feed::new(FeedType::Atom)
+    let expected = Feed::default()
         .title(Text::new("USGS Magnitude 2.5+ Earthquakes, Past Hour".into()))
         .updated_parsed("2019-07-31T13:17:27Z")
         .author(Person::new("U.S. Geological Survey")
@@ -232,7 +232,7 @@ fn test_example_6() {
     let test_data = test::fixture_as_string("atom/atom_example_6.xml");
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
-    let expected = Feed::new(FeedType::Atom)
+    let expected = Feed::default()
         .id("tag:github.com,2008:https://github.com/feed-rs/feed-rs/releases")
         .language("en-US")
         .link(
@@ -388,7 +388,7 @@ fn test_spec_1() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::Atom)
+    let expected = Feed::default()
         .id("urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6")
         .title(Text::new("Example Feed".into()))
         .link(Link::new("http://example.org/", None).rel("alternate"))
@@ -447,7 +447,7 @@ fn test_pub_spec_1() {
     let actual = parser::parse(test_data.as_bytes()).unwrap().id(""); // Clear randomly generated UUID
 
     // Expected feed
-    let expected = Feed::new(FeedType::Atom).entry(
+    let expected = Feed::default().entry(
         Entry::default()
             .title(Text::new("Atom-Powered Robots Run Amok".into()))
             .id("urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a")
@@ -466,7 +466,7 @@ fn test_entry() {
     let test_data = test::fixture_as_string("atom/atom_entry_1.xml");
     let actual = parser::parse(test_data.as_bytes()).unwrap().id("");
 
-    let expected = Feed::new(FeedType::Atom).entry(
+    let expected = Feed::default().entry(
         Entry::default()
             .title(Text::new("Specifications".into()))
             .id("urn:uuid:988EF5C55CDEA24EDE1251744888912")

--- a/feed-rs/src/parser/json/mod.rs
+++ b/feed-rs/src/parser/json/mod.rs
@@ -22,7 +22,10 @@ pub(crate) fn parse<R: Read>(parser: &Parser, stream: R) -> ParseFeedResult<Feed
 
 // Convert the JSON Feed into our standard model
 fn convert(parser: &Parser, jf: JsonFeed) -> ParseFeedResult<Feed> {
-    let mut feed = Feed::new(FeedType::JSON);
+    let mut feed = Feed {
+        feed_type: FeedType::JSON,
+        ..Feed::default()
+    };
 
     // If the version exists, it should be something we support
     if !jf.version.starts_with("https://jsonfeed.org/version/1") {

--- a/feed-rs/src/parser/json/tests.rs
+++ b/feed-rs/src/parser/json/tests.rs
@@ -10,7 +10,10 @@ fn test_example_1() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::JSON)
+    let expected = Feed {
+        feed_type: FeedType::JSON,
+        ..Feed::default()
+    }
         .id(&actual.id)                 // not in test content
         .updated(actual.updated)        // not in test content
         .title(Text::new("Daring Fireball".into()))
@@ -59,7 +62,10 @@ fn test_spec_1() {
     let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::JSON)
+    let expected = Feed {
+        feed_type: FeedType::JSON,
+        ..Feed::default()
+    }
         .id(&actual.id)                 // not in test content
         .updated(actual.updated)        // not in test content
         .title(Text::new("JSON Feed".into()))

--- a/feed-rs/src/parser/rss0/tests.rs
+++ b/feed-rs/src/parser/rss0/tests.rs
@@ -12,7 +12,10 @@ fn test_0_91_spec_1() {
     // Expected feed
     let entry0 = actual.entries.first().unwrap();
     let entry1 = actual.entries.get(1).unwrap();
-    let expected = Feed::new(FeedType::RSS0)
+    let expected = Feed {
+        feed_type: FeedType::RSS0,
+        ..Feed::default()
+    }
         .id(actual.id.as_ref())     // not present in the test data
         .title(Text::new("WriteTheWeb".into()))
         .link(Link::new("http://writetheweb.com", None))
@@ -94,7 +97,10 @@ fn test_0_92_spec_1() {
     let entry0 = actual.entries.first().unwrap();
     let entry1 = actual.entries.get(1).unwrap();
     let entry2 = actual.entries.get(2).unwrap();
-    let expected = Feed::new(FeedType::RSS0)
+    let expected = Feed {
+        feed_type: FeedType::RSS0,
+        ..Feed::default()
+    }
         .id(actual.id.as_ref())     // not present in the test data
         .title(Text::new("Dave Winer: Grateful Dead".into()))
         .link(Link::new("http://www.scripting.com/blog/categories/gratefulDead.html", None))

--- a/feed-rs/src/parser/rss1/mod.rs
+++ b/feed-rs/src/parser/rss1/mod.rs
@@ -10,7 +10,10 @@ mod tests;
 
 /// Parses an RSS 1.0 feed into our model
 pub(crate) fn parse<R: BufRead>(parser: &Parser, root: Element<R>) -> ParseFeedResult<Feed> {
-    let mut feed = Feed::new(FeedType::RSS1);
+    let mut feed = Feed {
+        feed_type: FeedType::RSS1,
+        ..Feed::default()
+    };
 
     for child in root.children() {
         let child = child?;

--- a/feed-rs/src/parser/rss1/tests.rs
+++ b/feed-rs/src/parser/rss1/tests.rs
@@ -14,33 +14,36 @@ fn test_example_1() {
     // Expected feed
     let entry0 = actual.entries.first().unwrap();
     let entry1 = actual.entries.get(1).unwrap();
-    let expected = Feed::new(FeedType::RSS1)
-        .id(actual.id.as_ref()) // not present in the test data
-        .title(Text::new("Feed title".into()))
-        .link(Link::new("http://www.example.com/main.html", None))
-        .description(Text::new("Site description".into()))
-        .updated(actual.updated) // not present in the test data
-        .published("2017-06-13T09:00:00Z")
-        .language("ja")
-        .entry(
-            Entry::default()
-                .id("7d61c42a2d8ecf2289e789e1fb2035d1") // hash of the link
-                .updated(entry0.updated) // not present in the test data
-                .title(Text::new("記事1のタイトル".into()))
-                .link(Link::new("記事1のURL", None))
-                .summary(Text::new("記事1の内容".into()))
-                .published("2017-06-13T09:00:00Z")
-                .author(Person::new("記事1の作者名")),
-        )
-        .entry(
-            Entry::default()
-                .id("e342c1b080da9ffbfd10c0a6ba49395f") // hash of the link
-                .updated(entry1.updated) // not present in the test data
-                .title(Text::new("記事2のタイトル".into()))
-                .link(Link::new("記事2のURL", None))
-                .summary(Text::new("記事2の内容".into()))
-                .author(Person::new("記事2の作者名")),
-        );
+    let expected = Feed {
+        feed_type: FeedType::RSS1,
+        ..Feed::default()
+    }
+    .id(actual.id.as_ref()) // not present in the test data
+    .title(Text::new("Feed title".into()))
+    .link(Link::new("http://www.example.com/main.html", None))
+    .description(Text::new("Site description".into()))
+    .updated(actual.updated) // not present in the test data
+    .published("2017-06-13T09:00:00Z")
+    .language("ja")
+    .entry(
+        Entry::default()
+            .id("7d61c42a2d8ecf2289e789e1fb2035d1") // hash of the link
+            .updated(entry0.updated) // not present in the test data
+            .title(Text::new("記事1のタイトル".into()))
+            .link(Link::new("記事1のURL", None))
+            .summary(Text::new("記事1の内容".into()))
+            .published("2017-06-13T09:00:00Z")
+            .author(Person::new("記事1の作者名")),
+    )
+    .entry(
+        Entry::default()
+            .id("e342c1b080da9ffbfd10c0a6ba49395f") // hash of the link
+            .updated(entry1.updated) // not present in the test data
+            .title(Text::new("記事2のタイトル".into()))
+            .link(Link::new("記事2のURL", None))
+            .summary(Text::new("記事2の内容".into()))
+            .author(Person::new("記事2の作者名")),
+    );
 
     // Check
     assert_eq!(actual, expected);
@@ -76,7 +79,10 @@ fn test_spec_1() {
     // Expected feed
     let entry0 = actual.entries.first().unwrap();
     let entry1 = actual.entries.get(1).unwrap();
-    let expected = Feed::new(FeedType::RSS1)
+    let expected = Feed {
+        feed_type: FeedType::RSS1,
+        ..Feed::default()
+    }
         .id(actual.id.as_ref())     // not present in the test data
         .title(Text::new("XML.com".into()))
         .link(Link::new("http://xml.com/pub", None))
@@ -111,31 +117,34 @@ fn test_spec_2() {
 
     // Expected feed
     let entry0 = actual.entries.first().unwrap();
-    let expected = Feed::new(FeedType::RSS1)
-        .id(actual.id.as_ref()) // not present in the test data
-        .title(Text::new("Meerkat".into()))
-        .link(Link::new("http://meerkat.oreillynet.com", None))
-        .description(Text::new("Meerkat: An Open Wire Service".into()))
-        .logo(
-            Image::new("http://meerkat.oreillynet.com/icons/meerkat-powered.jpg".into())
-                .link("http://meerkat.oreillynet.com")
-                .title("Meerkat Powered!"),
-        )
-        .updated(actual.updated) // not present in the test data
-        .author(Person::new("Rael Dornfest (mailto:rael@oreilly.com)"))
-        .rights(Text::new("Copyright © 2000 O'Reilly & Associates, Inc.".into()))
-        .entry(
-            Entry::default()
-                .id("acf7c86547d5d594af6d8f3327e84b06") // hash of the link
-                .updated(entry0.updated) // not present in the test data
-                .title(Text::new("XML: A Disruptive Technology".into()))
-                .link(Link::new("http://c.moreover.com/click/here.pl?r123", None))
-                .summary(Text::new(
-                    "XML is placing increasingly heavy loads on the existing technical\n            infrastructure of the Internet.".into(),
-                ))
-                .author(Person::new("Simon St.Laurent (mailto:simonstl@simonstl.com)"))
-                .rights(Text::new("Copyright © 2000 O'Reilly & Associates, Inc.".into())),
-        );
+    let expected = Feed {
+        feed_type: FeedType::RSS1,
+        ..Feed::default()
+    }
+    .id(actual.id.as_ref()) // not present in the test data
+    .title(Text::new("Meerkat".into()))
+    .link(Link::new("http://meerkat.oreillynet.com", None))
+    .description(Text::new("Meerkat: An Open Wire Service".into()))
+    .logo(
+        Image::new("http://meerkat.oreillynet.com/icons/meerkat-powered.jpg".into())
+            .link("http://meerkat.oreillynet.com")
+            .title("Meerkat Powered!"),
+    )
+    .updated(actual.updated) // not present in the test data
+    .author(Person::new("Rael Dornfest (mailto:rael@oreilly.com)"))
+    .rights(Text::new("Copyright © 2000 O'Reilly & Associates, Inc.".into()))
+    .entry(
+        Entry::default()
+            .id("acf7c86547d5d594af6d8f3327e84b06") // hash of the link
+            .updated(entry0.updated) // not present in the test data
+            .title(Text::new("XML: A Disruptive Technology".into()))
+            .link(Link::new("http://c.moreover.com/click/here.pl?r123", None))
+            .summary(Text::new(
+                "XML is placing increasingly heavy loads on the existing technical\n            infrastructure of the Internet.".into(),
+            ))
+            .author(Person::new("Simon St.Laurent (mailto:simonstl@simonstl.com)"))
+            .rights(Text::new("Copyright © 2000 O'Reilly & Associates, Inc.".into())),
+    );
 
     // Check
     assert_eq!(actual, expected);

--- a/feed-rs/src/parser/rss2/mod.rs
+++ b/feed-rs/src/parser/rss2/mod.rs
@@ -30,7 +30,10 @@ pub(crate) fn parse<R: BufRead>(parser: &Parser, root: Element<R>) -> ParseFeedR
 
 // Handles the <channel> element
 fn handle_channel<R: BufRead>(parser: &Parser, channel: Element<R>) -> ParseFeedResult<Feed> {
-    let mut feed = Feed::new(FeedType::RSS2);
+    let mut feed = Feed {
+        feed_type: FeedType::RSS2,
+        ..Feed::default()
+    };
 
     for child in channel.children() {
         let child = child?;

--- a/feed-rs/src/parser/rss2/tests.rs
+++ b/feed-rs/src/parser/rss2/tests.rs
@@ -17,23 +17,26 @@ fn test_example_1() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::RSS2)
-        .id(actual.id.as_ref()) // not present in the test data
-        .title(Text::new("RSS Title".into()))
-        .description(Text::new("This is an example of an RSS feed".into()))
-        .link(Link::new("http://www.example.com/main.html", None))
-        .updated_parsed("Mon, 06 Sep 2010 00:01:00 +0000")
-        .published("Sun, 06 Sep 2009 16:20:00 +0000")
-        .ttl(1800)
-        .entry(
-            Entry::default()
-                .title(Text::new("Example entry".into()))
-                .summary(Text::html("Here is some text containing an interesting description.".into()))
-                .link(Link::new("http://www.example.com/blog/post/1", None))
-                .id("7bd204c6-1655-4c27-aeee-53f933c5395f")
-                .published("Sun, 06 Sep 2009 16:20:00 +0000")
-                .updated_parsed("Sun, 06 Sep 2009 16:20:00 +0000"),
-        ); // copy from feed
+    let expected = Feed {
+        feed_type: FeedType::RSS2,
+        ..Feed::default()
+    }
+    .id(actual.id.as_ref()) // not present in the test data
+    .title(Text::new("RSS Title".into()))
+    .description(Text::new("This is an example of an RSS feed".into()))
+    .link(Link::new("http://www.example.com/main.html", None))
+    .updated_parsed("Mon, 06 Sep 2010 00:01:00 +0000")
+    .published("Sun, 06 Sep 2009 16:20:00 +0000")
+    .ttl(1800)
+    .entry(
+        Entry::default()
+            .title(Text::new("Example entry".into()))
+            .summary(Text::html("Here is some text containing an interesting description.".into()))
+            .link(Link::new("http://www.example.com/blog/post/1", None))
+            .id("7bd204c6-1655-4c27-aeee-53f933c5395f")
+            .published("Sun, 06 Sep 2009 16:20:00 +0000")
+            .updated_parsed("Sun, 06 Sep 2009 16:20:00 +0000"),
+    ); // copy from feed
 
     // Check
     assert_eq!(actual, expected);
@@ -47,34 +50,45 @@ fn test_example_2() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected: Feed = Feed::new(FeedType::RSS2)
-        .id(actual.id.as_ref())     // not present in the test data
-        .updated(actual.updated)    // not present in the test data
-        .title(Text::new("NASA Breaking News".into()))
-        .description(Text::new("A RSS news feed containing the latest NASA news articles and press releases.".into()))
-        .link(Link::new("http://www.nasa.gov/", None))
-        .link(Link::new("http://www.nasa.gov/rss/dyn/breaking_news.rss", None)
-            .rel("self"))
-        .language("en-us")
-        .contributor(Person::new("managingEditor")
-            .email("jim.wilson@nasa.gov"))
-        .contributor(Person::new("webMaster")
-            .email("brian.dunbar@nasa.gov"))
-        .entry(Entry::default()
+    let expected: Feed = Feed {
+        feed_type: FeedType::RSS2,
+        ..Feed::default()
+    }
+    .id(actual.id.as_ref()) // not present in the test data
+    .updated(actual.updated) // not present in the test data
+    .title(Text::new("NASA Breaking News".into()))
+    .description(Text::new("A RSS news feed containing the latest NASA news articles and press releases.".into()))
+    .link(Link::new("http://www.nasa.gov/", None))
+    .link(Link::new("http://www.nasa.gov/rss/dyn/breaking_news.rss", None).rel("self"))
+    .language("en-us")
+    .contributor(Person::new("managingEditor").email("jim.wilson@nasa.gov"))
+    .contributor(Person::new("webMaster").email("brian.dunbar@nasa.gov"))
+    .entry(
+        Entry::default()
             .title(Text::new("NASA Television to Broadcast Space Station Departure of Cygnus Cargo Ship".into()))
-            .link(Link::new("http://www.nasa.gov/press-release/nasa-television-to-broadcast-space-station-departure-of-cygnus-cargo-ship", None))
-            .summary(Text::html(r#"More than three months after delivering several tons of supplies and scientific experiments to
+            .link(Link::new(
+                "http://www.nasa.gov/press-release/nasa-television-to-broadcast-space-station-departure-of-cygnus-cargo-ship",
+                None,
+            ))
+            .summary(Text::html(
+                r#"More than three months after delivering several tons of supplies and scientific experiments to
                 the International Space Station, Northrop Grumman’s Cygnus cargo spacecraft, the SS Roger Chaffee, will
                 depart the orbiting laboratory Tuesday, Aug. 6.
-            "#.to_owned()))
+            "#
+                .to_owned(),
+            ))
             .id("http://www.nasa.gov/press-release/nasa-television-to-broadcast-space-station-departure-of-cygnus-cargo-ship")
             .published("Thu, 01 Aug 2019 16:15 EDT")
             .updated_parsed("Thu, 01 Aug 2019 16:15 EDT")
-            .media(MediaObject::default()
-                .content(MediaContent::new()
-                    .url("http://www.nasa.gov/sites/default/files/styles/1x1_cardfeed/public/thumbnails/image/47616261882_4bb534d293_k.jpg?itok=Djjjs81t")
-                    .content_type("image/jpeg")
-                    .size(892854))));
+            .media(
+                MediaObject::default().content(
+                    MediaContent::new()
+                        .url("http://www.nasa.gov/sites/default/files/styles/1x1_cardfeed/public/thumbnails/image/47616261882_4bb534d293_k.jpg?itok=Djjjs81t")
+                        .content_type("image/jpeg")
+                        .size(892854),
+                ),
+            ),
+    );
 
     // Check
     assert_eq!(actual, expected);
@@ -88,7 +102,10 @@ fn test_example_3() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::RSS2)
+    let expected = Feed {
+        feed_type: FeedType::RSS2,
+        ..Feed::default()
+    }
         .id(actual.id.as_ref())     // not present in the test data
         .title(Text::new("News, Politics, Opinion, Commentary, and Analysis".into()))
         .description(Text::new("In-depth reporting, commentary on breaking news, political analysis, and opinion from The New\n            Yorker.".into()))
@@ -127,7 +144,10 @@ fn test_example_4() {
     let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::RSS2)
+    let expected = Feed {
+        feed_type: FeedType::RSS2,
+        ..Feed::default()
+    }
         .id(actual.id.as_ref())     // not present in the test data
         .title(Text::new("Earthquakes today".into()))
         .link(Link::new("http://www.earthquakenewstoday.com/feed/", None)
@@ -165,50 +185,53 @@ fn test_example_5() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::RSS2)
-        .id(actual.id.as_ref()) // not present in the test data
-        .title(Text::new("Ars Technica".into()))
-        .link(Link::new("https://arstechnica.com", None))
-        .link(
-            Link::new("http://feeds.arstechnica.com/arstechnica/index", None)
-                .rel("self")
-                .media_type("application/rss+xml"),
-        )
-        .link(Link::new("http://pubsubhubbub.appspot.com/", None).rel("hub"))
-        .description(Text::new(
-            "Serving the Technologist for more than a decade. IT news, reviews, and analysis.".into(),
-        ))
-        .updated_parsed("Tue, 06 Aug 2019 00:03:56 +0000")
-        .language("en-us")
-        .generator(Generator::new("https://wordpress.org/?v=4.8.3"))
-        .logo(
-            Image::new("https://cdn.arstechnica.net/wp-content/uploads/2016/10/cropped-ars-logo-512_480-32x32.png".into())
-                .title("Ars Technica")
-                .link("https://arstechnica.com")
-                .width(32)
-                .height(32),
-        )
-        .entry(
-            Entry::default()
-                .title(Text::new(
-                    "Apple isn’t the most cash-rich company in the world anymore, but it doesn’t matter".into(),
-                ))
-                .link(Link::new("https://arstechnica.com/?p=1546121", None))
-                .published("Mon, 05 Aug 2019 23:11:09 +0000")
-                .updated_parsed("Mon, 05 Aug 2019 23:11:09 +0000")
-                .category(Category::new("Tech"))
-                .category(Category::new("alphabet"))
-                .category(Category::new("apple"))
-                .category(Category::new("google"))
-                .id("https://arstechnica.com/?p=1546121")
-                .author(Person::new("Samuel Axon"))
-                .summary(Text::html("Alphabet has $117 billion in cash on hand.".into()))
-                .content(
-                    Content::default()
-                        .body("Google co-founder Larry Page is now CEO of Alphabet.")
-                        .content_type("text/html"),
-                ),
-        );
+    let expected = Feed {
+        feed_type: FeedType::RSS2,
+        ..Feed::default()
+    }
+    .id(actual.id.as_ref()) // not present in the test data
+    .title(Text::new("Ars Technica".into()))
+    .link(Link::new("https://arstechnica.com", None))
+    .link(
+        Link::new("http://feeds.arstechnica.com/arstechnica/index", None)
+            .rel("self")
+            .media_type("application/rss+xml"),
+    )
+    .link(Link::new("http://pubsubhubbub.appspot.com/", None).rel("hub"))
+    .description(Text::new(
+        "Serving the Technologist for more than a decade. IT news, reviews, and analysis.".into(),
+    ))
+    .updated_parsed("Tue, 06 Aug 2019 00:03:56 +0000")
+    .language("en-us")
+    .generator(Generator::new("https://wordpress.org/?v=4.8.3"))
+    .logo(
+        Image::new("https://cdn.arstechnica.net/wp-content/uploads/2016/10/cropped-ars-logo-512_480-32x32.png".into())
+            .title("Ars Technica")
+            .link("https://arstechnica.com")
+            .width(32)
+            .height(32),
+    )
+    .entry(
+        Entry::default()
+            .title(Text::new(
+                "Apple isn’t the most cash-rich company in the world anymore, but it doesn’t matter".into(),
+            ))
+            .link(Link::new("https://arstechnica.com/?p=1546121", None))
+            .published("Mon, 05 Aug 2019 23:11:09 +0000")
+            .updated_parsed("Mon, 05 Aug 2019 23:11:09 +0000")
+            .category(Category::new("Tech"))
+            .category(Category::new("alphabet"))
+            .category(Category::new("apple"))
+            .category(Category::new("google"))
+            .id("https://arstechnica.com/?p=1546121")
+            .author(Person::new("Samuel Axon"))
+            .summary(Text::html("Alphabet has $117 billion in cash on hand.".into()))
+            .content(
+                Content::default()
+                    .body("Google co-founder Larry Page is now CEO of Alphabet.")
+                    .content_type("text/html"),
+            ),
+    );
 
     // Check
     assert_eq!(actual, expected);
@@ -224,7 +247,10 @@ fn test_example_6() {
     let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::RSS2)
+    let expected = Feed {
+        feed_type: FeedType::RSS2,
+        ..Feed::default()
+    }
         .id("b2ef47d837e6c0d9d757e14852e5bde")     // hash of the link
         .title(Text::new("Latest Movie Trailers".into()))
         .link(Link::new("https://trailers.apple.com/", None))
@@ -271,44 +297,47 @@ fn test_spec_1() {
     let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::RSS2)
-        .id(actual.id.as_ref()) // not present in the test data
-        .title(Text::new("Scripting News".into()))
-        .link(Link::new("http://www.scripting.com/", None))
-        .description(Text::new("A weblog about scripting and stuff like that.".into()))
-        .language("en-us")
-        .rights(Text::new("Copyright 1997-2002 Dave Winer".into()))
-        .updated_parsed("Mon, 30 Sep 2002 11:00:00 GMT")
-        .generator(Generator::new("Radio UserLand v8.0.5"))
-        .category(Category::new("1765").scheme("Syndic8"))
-        .contributor(Person::new("managingEditor").email("dave@userland.com"))
-        .contributor(Person::new("webMaster").email("dave@userland.com"))
-        .ttl(40)
-        .entry(
-            Entry::default()
-                .summary(Text::html(
-                    r#"Joshua Allen: <a href="http://www.netcrucible.com/blog/2002/09/29.html#a243">Who
+    let expected = Feed {
+        feed_type: FeedType::RSS2,
+        ..Feed::default()
+    }
+    .id(actual.id.as_ref()) // not present in the test data
+    .title(Text::new("Scripting News".into()))
+    .link(Link::new("http://www.scripting.com/", None))
+    .description(Text::new("A weblog about scripting and stuff like that.".into()))
+    .language("en-us")
+    .rights(Text::new("Copyright 1997-2002 Dave Winer".into()))
+    .updated_parsed("Mon, 30 Sep 2002 11:00:00 GMT")
+    .generator(Generator::new("Radio UserLand v8.0.5"))
+    .category(Category::new("1765").scheme("Syndic8"))
+    .contributor(Person::new("managingEditor").email("dave@userland.com"))
+    .contributor(Person::new("webMaster").email("dave@userland.com"))
+    .ttl(40)
+    .entry(
+        Entry::default()
+            .summary(Text::html(
+                r#"Joshua Allen: <a href="http://www.netcrucible.com/blog/2002/09/29.html#a243">Who
                 loves namespaces?</a>
             "#
-                    .to_owned(),
-                ))
-                .published("Sun, 29 Sep 2002 19:59:01 GMT")
-                .updated_parsed("Sun, 29 Sep 2002 19:59:01 GMT")
-                .id("http://scriptingnews.userland.com/backissues/2002/09/29#When:12:59:01PM"),
-        ) // copy from feed
-        .entry(
-            Entry::default()
-                .summary(Text::html(
-                    r#"<a href="http://www.docuverse.com/blog/donpark/2002/09/29.html#a68">Don Park</a>:
+                .to_owned(),
+            ))
+            .published("Sun, 29 Sep 2002 19:59:01 GMT")
+            .updated_parsed("Sun, 29 Sep 2002 19:59:01 GMT")
+            .id("http://scriptingnews.userland.com/backissues/2002/09/29#When:12:59:01PM"),
+    ) // copy from feed
+    .entry(
+        Entry::default()
+            .summary(Text::html(
+                r#"<a href="http://www.docuverse.com/blog/donpark/2002/09/29.html#a68">Don Park</a>:
                 "It is too easy for engineer to anticipate too much and XML Namespace is a frequent host of
                 over-anticipation."
             "#
-                    .to_owned(),
-                ))
-                .published("Mon, 30 Sep 2002 01:52:02 GMT")
-                .updated_parsed("Mon, 30 Sep 2002 01:52:02 GMT")
-                .id("http://scriptingnews.userland.com/backissues/2002/09/29#When:6:52:02PM"),
-        ); // copy from feed
+                .to_owned(),
+            ))
+            .published("Mon, 30 Sep 2002 01:52:02 GMT")
+            .updated_parsed("Mon, 30 Sep 2002 01:52:02 GMT")
+            .id("http://scriptingnews.userland.com/backissues/2002/09/29#When:6:52:02PM"),
+    ); // copy from feed
 
     // Check
     assert_eq!(actual, expected);
@@ -365,7 +394,10 @@ fn test_spiegel() {
     let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::RSS2)
+    let expected = Feed {
+        feed_type: FeedType::RSS2,
+        ..Feed::default()
+    }
         .id(actual.id.as_ref()) // not present in the test data
         .language("de")
         .title(Text::new("SPIEGEL Update – Die Nachrichten".into()))
@@ -446,56 +478,59 @@ fn test_bbc() {
     let actual = parser::parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::RSS2)
-        .id(actual.id.as_ref()) // not present in the test data
-        .title(Text::new("In Our Time".into()))
-        .link(Link::new("http://www.bbc.co.uk/programmes/b006qykl", None))
-        .link(
-            Link::new("http://www.bbc.co.uk/programmes/b006qykl/episodes/downloads.rss", None)
-                .rel("self")
-                .media_type("application/rss+xml"),
-        )
-        .category(Category::new("History"))
-        .description(Text::new("Melvyn Bragg and guests discuss the history of ideas".into()))
-        .author(Person::new("BBC Radio 4"))
-        .contributor(Person::new("BBC").email("RadioMusic.Support@bbc.co.uk"))
-        .language("en")
-        .logo(
-            Image::new("http://ichef.bbci.co.uk/images/ic/3000x3000/p087hyhs.jpg".into())
-                .title("In Our Time")
-                .link("http://www.bbc.co.uk/programmes/b006qykl"),
-        )
-        .rights(Text::new("(C) BBC 2021".into()))
-        .published("Thu, 25 Feb 2021 10:15:00 +0000")
-        .entry(
-            Entry::default()
-                .title(Text::new("Marcus Aurelius".into()))
-                .summary(Text::html("Melvyn Bragg and guests discuss...".into()))
-                .published("Thu, 25 Feb 2021 10:15:00 +0000")
-                .updated_parsed("Thu, 25 Feb 2021 10:15:00 +0000")
-                .id("urn:bbc:podcast:m000sjxt")
-                .link(Link::new("http://www.bbc.co.uk/programmes/m000sjxt", None))
-                // <enclosure>,  media: and itunes: tags
-                .media(
-                    MediaObject::default()
-                        .description("Melvyn Bragg and guests discuss the man who, according to Machiavelli...")
-                        .duration(Duration::from_secs(3156))
-                        .content(
-                            MediaContent::new()
-                                .url("http://open.live.bbc.co.uk/mediaselector/6/redir/version/2.0/mediaset/audio-nondrm-download/proto/http/vpid/p097wt5b.mp3")
-                                .size(50496000)
-                                .content_type("audio/mpeg"),
-                        )
-                        .content(
-                            MediaContent::new()
-                                .url("http://open.live.bbc.co.uk/mediaselector/6/redir/version/2.0/mediaset/audio-nondrm-download/proto/http/vpid/p097wt5b.mp3")
-                                .size(50496000)
-                                .content_type("audio/mpeg")
-                                .duration(Duration::from_secs(3156)),
-                        )
-                        .credit("BBC Radio 4"),
-                ),
-        );
+    let expected = Feed {
+        feed_type: FeedType::RSS2,
+        ..Feed::default()
+    }
+    .id(actual.id.as_ref()) // not present in the test data
+    .title(Text::new("In Our Time".into()))
+    .link(Link::new("http://www.bbc.co.uk/programmes/b006qykl", None))
+    .link(
+        Link::new("http://www.bbc.co.uk/programmes/b006qykl/episodes/downloads.rss", None)
+            .rel("self")
+            .media_type("application/rss+xml"),
+    )
+    .category(Category::new("History"))
+    .description(Text::new("Melvyn Bragg and guests discuss the history of ideas".into()))
+    .author(Person::new("BBC Radio 4"))
+    .contributor(Person::new("BBC").email("RadioMusic.Support@bbc.co.uk"))
+    .language("en")
+    .logo(
+        Image::new("http://ichef.bbci.co.uk/images/ic/3000x3000/p087hyhs.jpg".into())
+            .title("In Our Time")
+            .link("http://www.bbc.co.uk/programmes/b006qykl"),
+    )
+    .rights(Text::new("(C) BBC 2021".into()))
+    .published("Thu, 25 Feb 2021 10:15:00 +0000")
+    .entry(
+        Entry::default()
+            .title(Text::new("Marcus Aurelius".into()))
+            .summary(Text::html("Melvyn Bragg and guests discuss...".into()))
+            .published("Thu, 25 Feb 2021 10:15:00 +0000")
+            .updated_parsed("Thu, 25 Feb 2021 10:15:00 +0000")
+            .id("urn:bbc:podcast:m000sjxt")
+            .link(Link::new("http://www.bbc.co.uk/programmes/m000sjxt", None))
+            // <enclosure>,  media: and itunes: tags
+            .media(
+                MediaObject::default()
+                    .description("Melvyn Bragg and guests discuss the man who, according to Machiavelli...")
+                    .duration(Duration::from_secs(3156))
+                    .content(
+                        MediaContent::new()
+                            .url("http://open.live.bbc.co.uk/mediaselector/6/redir/version/2.0/mediaset/audio-nondrm-download/proto/http/vpid/p097wt5b.mp3")
+                            .size(50496000)
+                            .content_type("audio/mpeg"),
+                    )
+                    .content(
+                        MediaContent::new()
+                            .url("http://open.live.bbc.co.uk/mediaselector/6/redir/version/2.0/mediaset/audio-nondrm-download/proto/http/vpid/p097wt5b.mp3")
+                            .size(50496000)
+                            .content_type("audio/mpeg")
+                            .duration(Duration::from_secs(3156)),
+                    )
+                    .credit("BBC Radio 4"),
+            ),
+    );
 
     // Check
     assert_eq!(actual, expected);
@@ -511,124 +546,127 @@ fn test_ch9() {
     let actual = p.parse(test_data.as_bytes()).unwrap();
 
     // Expected feed
-    let expected = Feed::new(FeedType::RSS2)
-        .id(actual.id.as_ref()) // not present in the test data
-        .title(Text::new("Azure Friday (HD) - Channel 9".into()))
-        .logo(
-            Image::new("https://f.ch9.ms/thumbnail/4761e196-da48-4b41-abfe-e56e0509f04d.png".into())
-                .title("Azure Friday (HD) - Channel 9")
-                .link("https://s.ch9.ms/Shows/Azure-Friday"),
-        )
-        .description(Text::new(
-            "Join Scott Hanselman, Donovan Brown, or Lara Rubbelke as they host the engineers who build Azure, demo it, answer questions, and share insights."
-                .into(),
-        ))
-        .link(
-            Link::new("https://s.ch9.ms/Shows/Azure-Friday/feed/mp4high", None)
-                .rel("self")
-                .media_type("application/rss+xml"),
-        )
-        .link(Link::new("https://s.ch9.ms/Shows/Azure-Friday", None))
-        .category(Category::new("Technology"))
-        .language("en")
-        .published("Sat, 27 Feb 2021 06:55:01 GMT")
-        .updated_parsed("Sat, 27 Feb 2021 06:55:01 GMT")
-        .author(Person::new("Microsoft"))
-        .generator(Generator::new("Rev9"))
-        .entry(
-            Entry::default()
-                .title(Text::new("Troubleshoot AKS cluster issues with AKS Diagnostics and AKS Periscope".into()))
-                .summary(Text::html("<p>Yun Jung Choi shows Scott Hanselman...".into()))
-                .link(Link::new(
-                    "https://channel9.msdn.com/Shows/Azure-Friday/Troubleshoot-AKS-cluster-issues-with-AKS-Diagnostics-and-AKS-Periscope",
-                    None,
-                ))
-                .published("Fri, 26 Feb 2021 20:00:00 GMT")
-                .updated_parsed("Fri, 26 Feb 2021 20:00:00 GMT")
-                .id("https://channel9.msdn.com/Shows/Azure-Friday/Troubleshoot-AKS-cluster-issues-with-AKS-Diagnostics-and-AKS-Periscope")
-                .author(Person::new("Scott Hanselman, Rob Caron"))
-                .category(Category::new("Azure"))
-                .category(Category::new("Kubernetes"))
-                .category(Category::new("aft"))
-                // <media:group>
-                .media(
-                    MediaObject::default()
-                        .content(
-                            MediaContent::new()
-                                .url("https://rev9.blob.core.windows.net/mfupload/04b236b5-e824-4091-85d8-acd90155d4b0_20210124205102.mp4")
-                                .duration(Duration::from_secs(867))
-                                .size(1)
-                                .content_type("video/mp4"),
-                        )
-                        .content(
-                            MediaContent::new()
-                                .url("https://sec.ch9.ms/ch9/075d/6e61e6c6-3890-4172-a617-fa0c4b38075d/azfr663.mp3")
-                                .duration(Duration::from_secs(867))
-                                .size(13878646)
-                                .content_type("audio/mp3"),
-                        )
-                        .content(
-                            MediaContent::new()
-                                .url("https://sec.ch9.ms/ch9/075d/6e61e6c6-3890-4172-a617-fa0c4b38075d/azfr663.mp4")
-                                .duration(Duration::from_secs(867))
-                                .size(20450133)
-                                .content_type("video/mp4"),
-                        )
-                        .content(
-                            MediaContent::new()
-                                .url("https://sec.ch9.ms/ch9/075d/6e61e6c6-3890-4172-a617-fa0c4b38075d/azfr663_high.mp4")
-                                .duration(Duration::from_secs(867))
-                                .size(126659374)
-                                .content_type("video/mp4"),
-                        )
-                        .content(
-                            MediaContent::new()
-                                .url("https://sec.ch9.ms/ch9/075d/6e61e6c6-3890-4172-a617-fa0c4b38075d/azfr663_mid.mp4")
-                                .duration(Duration::from_secs(867))
-                                .size(49241848)
-                                .content_type("video/mp4"),
-                        )
-                        .content(
-                            MediaContent::new()
-                                .url("https://www.youtube-nocookie.com/embed/E-XqYb88hUY?enablejsapi=1")
-                                .duration(Duration::from_secs(867))
-                                .size(1),
-                        ),
-                )
-                // <enclosure> and <media:*>
-                .media(
-                    MediaObject::default()
-                        .description("Yun Jung Choi shows Scott Hanselman how to use AKS Diagnostics...")
-                        .duration(Duration::from_secs(867))
-                        .thumbnail(MediaThumbnail::new(
-                            Image::new("https://sec.ch9.ms/ch9/3724/8609074c-2b7b-41ae-9345-f49973543724/azfr663_100.jpg".into())
-                                .height(56)
-                                .width(100),
-                        ))
-                        .thumbnail(MediaThumbnail::new(
-                            Image::new("https://sec.ch9.ms/ch9/3724/8609074c-2b7b-41ae-9345-f49973543724/azfr663_220.jpg".into())
-                                .height(123)
-                                .width(220),
-                        ))
-                        .thumbnail(MediaThumbnail::new(
-                            Image::new("https://sec.ch9.ms/ch9/3724/8609074c-2b7b-41ae-9345-f49973543724/azfr663_512.jpg".into())
-                                .height(288)
-                                .width(512),
-                        ))
-                        .thumbnail(MediaThumbnail::new(
-                            Image::new("https://sec.ch9.ms/ch9/3724/8609074c-2b7b-41ae-9345-f49973543724/azfr663_960.jpg".into())
-                                .height(540)
-                                .width(960),
-                        ))
-                        .content(
-                            MediaContent::new()
-                                .url("https://sec.ch9.ms/ch9/075d/6e61e6c6-3890-4172-a617-fa0c4b38075d/azfr663_high.mp4")
-                                .size(126659374)
-                                .content_type("video/mp4"),
-                        )
-                        .credit("Scott Hanselman, Rob Caron"),
-                ),
-        );
+    let expected = Feed {
+        feed_type: FeedType::RSS2,
+        ..Feed::default()
+    }
+    .id(actual.id.as_ref()) // not present in the test data
+    .title(Text::new("Azure Friday (HD) - Channel 9".into()))
+    .logo(
+        Image::new("https://f.ch9.ms/thumbnail/4761e196-da48-4b41-abfe-e56e0509f04d.png".into())
+            .title("Azure Friday (HD) - Channel 9")
+            .link("https://s.ch9.ms/Shows/Azure-Friday"),
+    )
+    .description(Text::new(
+        "Join Scott Hanselman, Donovan Brown, or Lara Rubbelke as they host the engineers who build Azure, demo it, answer questions, and share insights."
+            .into(),
+    ))
+    .link(
+        Link::new("https://s.ch9.ms/Shows/Azure-Friday/feed/mp4high", None)
+            .rel("self")
+            .media_type("application/rss+xml"),
+    )
+    .link(Link::new("https://s.ch9.ms/Shows/Azure-Friday", None))
+    .category(Category::new("Technology"))
+    .language("en")
+    .published("Sat, 27 Feb 2021 06:55:01 GMT")
+    .updated_parsed("Sat, 27 Feb 2021 06:55:01 GMT")
+    .author(Person::new("Microsoft"))
+    .generator(Generator::new("Rev9"))
+    .entry(
+        Entry::default()
+            .title(Text::new("Troubleshoot AKS cluster issues with AKS Diagnostics and AKS Periscope".into()))
+            .summary(Text::html("<p>Yun Jung Choi shows Scott Hanselman...".into()))
+            .link(Link::new(
+                "https://channel9.msdn.com/Shows/Azure-Friday/Troubleshoot-AKS-cluster-issues-with-AKS-Diagnostics-and-AKS-Periscope",
+                None,
+            ))
+            .published("Fri, 26 Feb 2021 20:00:00 GMT")
+            .updated_parsed("Fri, 26 Feb 2021 20:00:00 GMT")
+            .id("https://channel9.msdn.com/Shows/Azure-Friday/Troubleshoot-AKS-cluster-issues-with-AKS-Diagnostics-and-AKS-Periscope")
+            .author(Person::new("Scott Hanselman, Rob Caron"))
+            .category(Category::new("Azure"))
+            .category(Category::new("Kubernetes"))
+            .category(Category::new("aft"))
+            // <media:group>
+            .media(
+                MediaObject::default()
+                    .content(
+                        MediaContent::new()
+                            .url("https://rev9.blob.core.windows.net/mfupload/04b236b5-e824-4091-85d8-acd90155d4b0_20210124205102.mp4")
+                            .duration(Duration::from_secs(867))
+                            .size(1)
+                            .content_type("video/mp4"),
+                    )
+                    .content(
+                        MediaContent::new()
+                            .url("https://sec.ch9.ms/ch9/075d/6e61e6c6-3890-4172-a617-fa0c4b38075d/azfr663.mp3")
+                            .duration(Duration::from_secs(867))
+                            .size(13878646)
+                            .content_type("audio/mp3"),
+                    )
+                    .content(
+                        MediaContent::new()
+                            .url("https://sec.ch9.ms/ch9/075d/6e61e6c6-3890-4172-a617-fa0c4b38075d/azfr663.mp4")
+                            .duration(Duration::from_secs(867))
+                            .size(20450133)
+                            .content_type("video/mp4"),
+                    )
+                    .content(
+                        MediaContent::new()
+                            .url("https://sec.ch9.ms/ch9/075d/6e61e6c6-3890-4172-a617-fa0c4b38075d/azfr663_high.mp4")
+                            .duration(Duration::from_secs(867))
+                            .size(126659374)
+                            .content_type("video/mp4"),
+                    )
+                    .content(
+                        MediaContent::new()
+                            .url("https://sec.ch9.ms/ch9/075d/6e61e6c6-3890-4172-a617-fa0c4b38075d/azfr663_mid.mp4")
+                            .duration(Duration::from_secs(867))
+                            .size(49241848)
+                            .content_type("video/mp4"),
+                    )
+                    .content(
+                        MediaContent::new()
+                            .url("https://www.youtube-nocookie.com/embed/E-XqYb88hUY?enablejsapi=1")
+                            .duration(Duration::from_secs(867))
+                            .size(1),
+                    ),
+            )
+            // <enclosure> and <media:*>
+            .media(
+                MediaObject::default()
+                    .description("Yun Jung Choi shows Scott Hanselman how to use AKS Diagnostics...")
+                    .duration(Duration::from_secs(867))
+                    .thumbnail(MediaThumbnail::new(
+                        Image::new("https://sec.ch9.ms/ch9/3724/8609074c-2b7b-41ae-9345-f49973543724/azfr663_100.jpg".into())
+                            .height(56)
+                            .width(100),
+                    ))
+                    .thumbnail(MediaThumbnail::new(
+                        Image::new("https://sec.ch9.ms/ch9/3724/8609074c-2b7b-41ae-9345-f49973543724/azfr663_220.jpg".into())
+                            .height(123)
+                            .width(220),
+                    ))
+                    .thumbnail(MediaThumbnail::new(
+                        Image::new("https://sec.ch9.ms/ch9/3724/8609074c-2b7b-41ae-9345-f49973543724/azfr663_512.jpg".into())
+                            .height(288)
+                            .width(512),
+                    ))
+                    .thumbnail(MediaThumbnail::new(
+                        Image::new("https://sec.ch9.ms/ch9/3724/8609074c-2b7b-41ae-9345-f49973543724/azfr663_960.jpg".into())
+                            .height(540)
+                            .width(960),
+                    ))
+                    .content(
+                        MediaContent::new()
+                            .url("https://sec.ch9.ms/ch9/075d/6e61e6c6-3890-4172-a617-fa0c4b38075d/azfr663_high.mp4")
+                            .size(126659374)
+                            .content_type("video/mp4"),
+                    )
+                    .credit("Scott Hanselman, Rob Caron"),
+            ),
+    );
 
     // Check
     assert_eq!(actual, expected);


### PR DESCRIPTION
This commit contains a lot of whitespace only changes introduced by rustfmt and should therefor best be reviewed with `git diff -w`.

I'm trying to implement an atom serializer as mentioned in https://github.com/feed-rs/feed-rs/issues/258 and missed a possibility to easily create a Feed instance without providing trivial empty values for all 18 members of the Feed struct.

While looking at the Feed code in https://github.com/feed-rs/feed-rs/blob/master/feed-rs/src/model.rs I discovered that you apparently felt the exact same thing and provided Feed::new(FeedType), but only visible to the crate.