### PR TITLE
feat: make id generator and timestamp parser send + sync

### DIFF
--- a/feed-rs/src/parser/mod.rs
+++ b/feed-rs/src/parser/mod.rs
@@ -252,7 +252,7 @@ impl Builder {
     /// Registers an ID generator
     pub fn id_generator<F>(mut self, generator: F) -> Self
     where
-        F: Fn(&[model::Link], &Option<model::Text>, Option<&str>) -> String + 'static,
+        F: Fn(&[model::Link], &Option<model::Text>, Option<&str>) -> String + 'static + Send + Sync,
     {
         self.id_generator = Box::new(generator);
         self
@@ -286,7 +286,7 @@ impl Builder {
     /// Registers a custom timestamp parser
     pub fn timestamp_parser<F>(mut self, ts_parser: F) -> Self
     where
-        F: Fn(&str) -> Option<DateTime<Utc>> + 'static,
+        F: Fn(&str) -> Option<DateTime<Utc>> + 'static + Send + Sync,
     {
         self.timestamp_parser = Box::new(ts_parser);
         self

--- a/feed-rs/src/parser/util.rs
+++ b/feed-rs/src/parser/util.rs
@@ -78,10 +78,10 @@ mod fixes {
 static RFC1123_FORMAT_STR: &str = "%d %b %Y %H:%M:%S %z";
 
 /// Pluggable timestamp parser
-pub(crate) type TimestampParser = dyn Fn(&str) -> Option<DateTime<Utc>> + 'static;
+pub(crate) type TimestampParser = dyn Fn(&str) -> Option<DateTime<Utc>> + 'static + Send + Sync;
 
 /// Pluggable ID (feed or entry) generator
-pub(crate) type IdGenerator = dyn Fn(&[Link], &Option<Text>, Option<&str>) -> String;
+pub(crate) type IdGenerator = dyn Fn(&[Link], &Option<Text>, Option<&str>) -> String + Send + Sync;
 
 /// Handles <content:encoded>
 pub(crate) fn handle_encoded<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Text>> {


### PR DESCRIPTION
Otherwise the `Parser` is not `Send`/`Sync` which makes it more difficult to use in multi threaded async runtimes.
This is a breaking change!