### PR TITLE
Update Cargo.toml

### DIFF
--- a/feed-rs/Cargo.toml
+++ b/feed-rs/Cargo.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 travis-ci = { repository = "feed-rs/feed-rs", branch = "master" }
 
 [dependencies]
-ammonia = { version = "4.0.0", optional = true }
+ammonia = { version = "4.1.2", optional = true }
 chrono = { version = "0.4.38", features = ["serde"] }
 mediatype = { version = "0.19.18", features = ["serde"] }
 quick-xml = { version = "0.37.1", features = ["encoding"] }


### PR DESCRIPTION
Bumps the dependency to at least 4.1.2 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2025-0071.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)