### PR TITLE
parser : add line numbers to semantic parse error

### DIFF
--- a/feed-rs/src/model.rs
+++ b/feed-rs/src/model.rs
@@ -1263,7 +1263,7 @@ impl FromStr for Role {
             "Assistant Camera" => Ok(Role::AssistantCamera),
             "Editor" => Ok(Role::Editor),
             "Assistant Editor" => Ok(Role::AssistantEditor),
-            _ => Err(ParseFeedError::ParseError(ParseErrorKind::UnknownEnumVariant(s.to_string()))),
+            _ => Err(ParseFeedError::parse(ParseErrorKind::UnknownEnumVariant(s.to_string()))),
         }
     }
 }
@@ -1310,7 +1310,7 @@ impl FromStr for Group {
             "Video Production" => Ok(Group::VideoProduction),
             "Visuals" => Ok(Group::Visuals),
             "Writing" => Ok(Group::Writing),
-            _ => Err(ParseFeedError::ParseError(ParseErrorKind::UnknownEnumVariant(s.to_string()))),
+            _ => Err(ParseFeedError::parse(ParseErrorKind::UnknownEnumVariant(s.to_string()))),
         }
     }
 }

--- a/feed-rs/src/parser/atom/mod.rs
+++ b/feed-rs/src/parser/atom/mod.rs
@@ -1,13 +1,13 @@
 use std::io::BufRead;
 
-use mediatype::{MediaTypeBuf, names};
+use mediatype::{names, MediaTypeBuf};
 
 use crate::model::{Category, Content, Entry, Feed, FeedType, Generator, Image, Link, MediaObject, Person, Text};
 use crate::parser::mediarss::handle_media_element;
 use crate::parser::util;
 use crate::parser::util::if_some_then;
+use crate::parser::{mediarss, Parser};
 use crate::parser::{ParseErrorKind, ParseFeedError, ParseFeedResult};
-use crate::parser::{Parser, mediarss};
 use crate::xml::{Element, NS};
 
 #[cfg(test)]
@@ -94,13 +94,14 @@ fn handle_category<R: BufRead>(element: Element<R>) -> Option<Category> {
 fn handle_content<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Content>> {
     // Extract the content type so we can parse the body
     let content_type = element.attr_value("type");
+    let line = element.line_number();
 
     if let Some(src) = element.attr_value("src") {
         // > If the "src" attribute is present, the "type" attribute SHOULD be provided and MUST be a MIME media type, rather than "text", "html", or "xhtml".
         let mime = match &content_type {
             Some(ct) => ct
                 .parse::<MediaTypeBuf>()
-                .map_err(|_| ParseFeedError::ParseError(ParseErrorKind::UnknownMimeType(ct.into())))?,
+                .map_err(|_| ParseFeedError::parse_at_line(ParseErrorKind::UnknownMimeType(ct.into()), line))?,
             None => {
                 // According to the spec the content type only SHOULD be provided.
                 // Unfortunately `Content` has media type as required. So we treat a missing type as text/html as that is probably the most common. Not to mention that `body` will be `None` so we are just providing a content type for nothing.
@@ -111,7 +112,10 @@ fn handle_content<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Con
         if element.child_as_text().is_some() {
             // > If the "src" attribute is present, atom:content MUST be empty.
             // `ParseFeedError` has no appropriate error type, so use `MissingContent` which is what would have been returned before support for `src` was added.
-            return Err(ParseFeedError::ParseError(ParseErrorKind::MissingContent("non-empty atom:content with src")));
+            return Err(ParseFeedError::parse_at_line(
+                ParseErrorKind::MissingContent("non-empty atom:content with src"),
+                line,
+            ));
         }
 
         let content = Content {
@@ -143,7 +147,7 @@ fn handle_content<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Con
                     Some(content)
                 })
                 // The text is required for a text or HTML element
-                .ok_or(ParseFeedError::ParseError(ParseErrorKind::MissingContent("content.text")))
+                .ok_or(ParseFeedError::parse_at_line(ParseErrorKind::MissingContent("content.text"), line))
         }
 
         // XML per "Otherwise, if the type attribute ends in +xml or /xml, then an xml document of this type is contained inline."
@@ -156,7 +160,7 @@ fn handle_content<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Con
                     Some(content)
                 })
                 // The XML is required for an XML content element
-                .ok_or(ParseFeedError::ParseError(ParseErrorKind::MissingContent("content.xml")))
+                .ok_or(ParseFeedError::parse_at_line(ParseErrorKind::MissingContent("content.xml"), line))
         }
 
         // Escaped text per "Otherwise, if the type attribute starts with text, then an escaped document of this type is contained inline." and
@@ -174,9 +178,9 @@ fn handle_content<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Con
                         Some(content)
                     })
                     // The text is required for an inline text or base64 element
-                    .ok_or(ParseFeedError::ParseError(ParseErrorKind::MissingContent("content.inline")))
+                    .ok_or(ParseFeedError::parse_at_line(ParseErrorKind::MissingContent("content.inline"), line))
             } else {
-                Err(ParseFeedError::ParseError(ParseErrorKind::UnknownMimeType(ct.into())))
+                Err(ParseFeedError::parse_at_line(ParseErrorKind::UnknownMimeType(ct.into()), line))
             }
         }
     }
@@ -323,13 +327,13 @@ fn handle_person<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Pers
 pub(crate) fn handle_text<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Text>> {
     // Find type, defaulting to "text" if not present
     let type_attr = element.attributes.iter().find(|a| &a.name == "type").map_or("text", |a| a.value.as_str());
-
+    let line = element.line_number();
     let mime = match type_attr {
         "text" => Ok(MediaTypeBuf::new(names::TEXT, names::PLAIN)),
         "html" | "xhtml" | "text/html" => Ok(MediaTypeBuf::new(names::TEXT, names::HTML)),
 
         // Unknown content type
-        _ => Err(ParseFeedError::ParseError(ParseErrorKind::UnknownMimeType(type_attr.into()))),
+        _ => Err(ParseFeedError::parse_at_line(ParseErrorKind::UnknownMimeType(type_attr.into()), line)),
     }?;
 
     element
@@ -340,5 +344,5 @@ pub(crate) fn handle_text<R: BufRead>(element: Element<R>) -> ParseFeedResult<Op
             Some(text)
         })
         // Need the text for a text element
-        .ok_or(ParseFeedError::ParseError(ParseErrorKind::MissingContent("text")))
+        .ok_or(ParseFeedError::parse_at_line(ParseErrorKind::MissingContent("text"), line))
 }

--- a/feed-rs/src/parser/mediarss.rs
+++ b/feed-rs/src/parser/mediarss.rs
@@ -1,11 +1,11 @@
 use std::io::BufRead;
 use std::time::Duration;
 
-use mediatype::{MediaTypeBuf, names};
+use mediatype::{names, MediaTypeBuf};
 
 use crate::model::{Image, MediaCommunity, MediaContent, MediaCredit, MediaObject, MediaRating, MediaText, MediaThumbnail, Text};
 use crate::parser::util::{if_ok_then_some, if_some_then, parse_npt};
-use crate::parser::{ParseErrorKind, ParseFeedError, ParseFeedResult, util};
+use crate::parser::{util, ParseErrorKind, ParseFeedError, ParseFeedResult};
 use crate::xml::{Element, NS};
 
 // TODO When an element appears at a shallow level, such as <channel> or <item>, it means that the element should be applied to every media object within its scope.
@@ -268,13 +268,14 @@ fn handle_media_thumbnail<R: BufRead>(element: Element<R>) -> Option<MediaThumbn
 fn handle_text<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Text>> {
     // Find type, defaulting to "plain" if not present
     let type_attr = element.attributes.iter().find(|a| &a.name == "type").map_or("plain", |a| a.value.as_str());
+    let line = element.line_number();
 
     let mime = match type_attr {
         "plain" => Ok(MediaTypeBuf::new(names::TEXT, names::PLAIN)),
         "html" => Ok(MediaTypeBuf::new(names::TEXT, names::HTML)),
 
         // Unknown content type
-        _ => Err(ParseFeedError::ParseError(ParseErrorKind::UnknownMimeType(type_attr.into()))),
+        _ => Err(ParseFeedError::parse_at_line(ParseErrorKind::UnknownMimeType(type_attr.into()), line)),
     }?;
 
     element
@@ -285,5 +286,5 @@ fn handle_text<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<Text>>
             Some(text)
         })
         // Need the text for a text element
-        .ok_or(ParseFeedError::ParseError(ParseErrorKind::MissingContent("text")))
+        .ok_or(ParseFeedError::parse_at_line(ParseErrorKind::MissingContent("text"), line))
 }

--- a/feed-rs/src/parser/mod.rs
+++ b/feed-rs/src/parser/mod.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
-use std::fmt;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::hash::Hasher;
 use std::io::{BufRead, BufReader, Read};
 
@@ -28,7 +27,7 @@ pub type ParseFeedResult<T> = Result<T, ParseFeedError>;
 #[derive(Debug)]
 pub enum ParseFeedError {
     // TODO add line number/position
-    ParseError(ParseErrorKind),
+    ParseError { kind: ParseErrorKind, line: Option<usize> },
     // IO error
     IoError(std::io::Error),
     // Underlying issue with JSON (poorly formatted etc.)
@@ -37,6 +36,21 @@ pub enum ParseFeedError {
     JsonUnsupportedVersion(String),
     // Underlying issue with XML (poorly formatted etc.)
     XmlReader(xml::XmlError),
+}
+
+impl ParseFeedError {
+    pub(crate) fn parse(kind: ParseErrorKind) -> Self {
+        Self::ParseError { kind, line: None }
+    }
+    pub(crate) fn parse_at_line(kind: ParseErrorKind, line: usize) -> Self {
+        Self::ParseError { kind, line: Some(line) }
+    }
+    pub(crate) fn with_line(self, line: usize) -> Self {
+        match self {
+            Self::ParseError { kind, line: None } => Self::ParseError { kind, line: Some(line) },
+            other => other,
+        }
+    }
 }
 
 impl From<serde_json::error::Error> for ParseFeedError {
@@ -60,7 +74,8 @@ impl From<xml::XmlError> for ParseFeedError {
 impl fmt::Display for ParseFeedError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ParseFeedError::ParseError(pe) => write!(f, "unable to parse feed: {}", pe),
+            ParseFeedError::ParseError { kind, line: Some(line_number) } => write!(f, "unable to parse feed: {} at line {}", kind, line_number),
+            ParseFeedError::ParseError { kind, line: None } => write!(f, "unable to parse deed: {}", kind),
             ParseFeedError::IoError(ie) => write!(f, "unable to read feed: {}", ie),
             ParseFeedError::JsonSerde(je) => write!(f, "unable to parse JSON: {}", je),
             ParseFeedError::JsonUnsupportedVersion(version) => write!(f, "unsupported version: {}", version),
@@ -155,7 +170,7 @@ impl Parser {
 
             Some('{') => self.parse_json(input),
 
-            _ => Err(ParseFeedError::ParseError(ParseErrorKind::NoFeedRoot)),
+            _ => Err(ParseFeedError::parse(ParseErrorKind::NoFeedRoot)),
         };
 
         // Post-processing as required
@@ -188,9 +203,11 @@ impl Parser {
     fn parse_xml<R: BufRead>(&self, source: R) -> ParseFeedResult<model::Feed> {
         // Set up the source of XML elements from the input
         let element_source = xml::ElementSource::new(source, self.base_uri.as_deref())?;
-        if let Ok(Some(root)) = element_source.root() {
+        // Propagate XML errors through ?
+        if let Some(root) = element_source.root()? {
             // Dispatch to the correct parser
             let version = root.attr_value("version");
+            let line = root.line_number();
             match (root.name.as_str(), version.as_deref()) {
                 ("feed", _) => {
                     element_source.set_default_default_namespace(NS::Atom);
@@ -212,12 +229,12 @@ impl Parser {
                     element_source.set_default_default_namespace(NS::RSS);
                     return rss1::parse(self, root);
                 }
-                _ => {}
-            };
+                _ => {
+                    return Err(ParseFeedError::parse_at_line(ParseErrorKind::NoFeedRoot, line));
+                }
+            }
         }
-
-        // Couldn't find a recognised feed within the provided XML stream
-        Err(ParseFeedError::ParseError(ParseErrorKind::NoFeedRoot))
+        Err(ParseFeedError::parse(ParseErrorKind::NoFeedRoot))
     }
 }
 

--- a/feed-rs/src/parser/podcast.rs
+++ b/feed-rs/src/parser/podcast.rs
@@ -1,6 +1,6 @@
 use crate::model::{Feed, Group, MediaObject, PodcastPerson, Role, Transcript};
 use crate::parser::util::{if_some_then, parse_uri};
-use crate::parser::{ParseFeedResult, util};
+use crate::parser::{util, ParseFeedResult};
 use crate::xml::{Element, NS};
 use mediatype::MediaTypeBuf;
 use std::io::BufRead;
@@ -36,13 +36,18 @@ pub(crate) fn handle_podcast_item_element<R: BufRead>(element: Element<R>, media
 
 // Handles <podcast:person>
 fn handle_person<R: BufRead>(element: Element<R>) -> ParseFeedResult<Option<PodcastPerson>> {
+    let line = element.line_number();
     if let Some(role) = element.attr_value("role") {
-        let role = Role::from_str(&role)?;
+        let role = Role::from_str(&role).map_err(|e| e.with_line(line))?;
         if let Some(name) = element.child_as_text() {
             return Ok(Some(PodcastPerson {
                 name,
                 role,
-                group: element.attr_value("group").map(|g| Group::from_str(&g)).transpose()?.unwrap_or_default(),
+                group: element
+                    .attr_value("group")
+                    .map(|g| Group::from_str(&g).map_err(|e| e.with_line(line)))
+                    .transpose()?
+                    .unwrap_or_default(),
                 img: element.attr_value("img").and_then(|img| Url::parse(&img).ok()),
                 href: element.attr_value("href").and_then(|href| Url::parse(&href).ok()),
             }));

--- a/feed-rs/src/parser/rss2/mod.rs
+++ b/feed-rs/src/parser/rss2/mod.rs
@@ -25,7 +25,7 @@ pub(crate) fn parse<R: BufRead>(parser: &Parser, root: Element<R>) -> ParseFeedR
     if let Some(channel) = found_channel {
         handle_channel(parser, channel?)
     } else {
-        Err(ParseFeedError::ParseError(ParseErrorKind::NoFeedRoot))
+        Err(ParseFeedError::parse(ParseErrorKind::NoFeedRoot))
     }
 }
 

--- a/feed-rs/src/parser/tests.rs
+++ b/feed-rs/src/parser/tests.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 use crate::model::Feed;
-use crate::parser;
+use crate::parser::{self, ParseErrorKind, ParseFeedError};
 use crate::util::test;
 
 // Regression test for the default ID generator
@@ -83,5 +83,170 @@ fn replace_ids(expected: &mut Feed, actual: &mut Feed) {
         if Uuid::parse_str(&expected_entry.id).is_ok() {
             actual_entry.id = expected_entry.id.clone();
         }
+    }
+}
+
+// Verifies line numbers are attached to semantic Atom parse failures
+#[test]
+fn atom_unknown_text_type_reports_line_number() {
+    let xml = concat!(
+        r#"<feed xmlns="http://www.w3.org/2005/Atom">"#,
+        "\n",
+        r#"<title type="[ERROR]">sample feed</title>"#,
+        "\n",
+        r#"<updated>2005-07-31T12:29:29Z</updated>"#,
+        "\n",
+        r#"<id>feed1</id>"#,
+        "\n",
+        r#"</feed>"#,
+    );
+    match parser::parse(xml.as_bytes()) {
+        Err(ParseFeedError::ParseError {
+            kind: ParseErrorKind::UnknownMimeType(mime),
+            line,
+        }) => {
+            assert_eq!(mime, "[ERROR]");
+            assert_eq!(line, Some(2));
+        }
+        other => panic!("unexpected result: {:?}", other),
+    }
+}
+
+// Verifies invalid podcast enum values are reported with the element line number
+#[test]
+fn podcast_invalid_role_reports_line_number() {
+    let xml = concat!(
+        r#"<rss version="2.0" xmlns:podcast="https://podcastindex.org/namespace/1.0">"#,
+        "\n",
+        r#"<channel>"#,
+        "\n",
+        r#"<title>podcast</title>"#,
+        "\n",
+        r#"<link>https://example.com</link>"#,
+        "\n",
+        r#"<description>desc</description>"#,
+        "\n",
+        r#"<podcast:person role="[ERROR]">Alice</podcast:person>"#,
+        "\n",
+        r#"<item>"#,
+        "\n",
+        r#"<title>entry</title>"#,
+        "\n",
+        r#"<link>https://example.com/1</link>"#,
+        "\n",
+        r#"<guid>1</guid>"#,
+        "\n",
+        r#"</item>"#,
+        "\n",
+        r#"</channel>"#,
+        "\n",
+        r#"</rss>"#,
+    );
+    match parser::parse(xml.as_bytes()) {
+        Err(ParseFeedError::ParseError {
+            kind: ParseErrorKind::UnknownEnumVariant(value),
+            line,
+        }) => {
+            assert_eq!(value, "[ERROR]");
+            assert_eq!(line, Some(6));
+        }
+        other => panic!("unexpected result: {:?}", other),
+    }
+}
+
+// Verifies an unrecognised XML root reports the root element line number
+#[test]
+fn unknown_xml_root_reports_line_number() {
+    let xml = concat!(r#"<notafeed>"#, "\n", r#"<title>nope</title>"#, "\n", r#"</notafeed>"#,);
+    match parser::parse(xml.as_bytes()) {
+        Err(ParseFeedError::ParseError {
+            kind: ParseErrorKind::NoFeedRoot,
+            line,
+        }) => {
+            assert_eq!(line, Some(1));
+        }
+        other => panic!("unexpected result: {:?}", other),
+    }
+}
+
+// Verifies failures without an element context do not report a line number
+#[test]
+fn no_feed_root_without_element_has_no_line() {
+    match parser::parse("not a feed".as_bytes()) {
+        Err(ParseFeedError::ParseError {
+            kind: ParseErrorKind::NoFeedRoot,
+            line,
+        }) => {
+            assert_eq!(line, None);
+        }
+        other => panic!("unexpected result: {:?}", other),
+    }
+}
+
+// Verifies MediaRSS parse failures report the element line number
+#[test]
+fn mediarss_invalid_text_type_reports_line_number() {
+    let xml = concat!(
+        r#"<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">"#,
+        "\n",
+        r#"<channel>"#,
+        "\n",
+        r#"<title>feed</title>"#,
+        "\n",
+        r#"<link>https://example.com</link>"#,
+        "\n",
+        r#"<description>desc</description>"#,
+        "\n",
+        r#"<item>"#,
+        "\n",
+        r#"<title>entry</title>"#,
+        "\n",
+        r#"<link>https://example.com/1</link>"#,
+        "\n",
+        r#"<guid>1</guid>"#,
+        "\n",
+        r#"<media:title type="[ERROR]">bad</media:title>"#,
+        "\n",
+        r#"</item>"#,
+        "\n",
+        r#"</channel>"#,
+        "\n",
+        r#"</rss>"#,
+    );
+    match parser::parse(xml.as_bytes()) {
+        Err(ParseFeedError::ParseError {
+            kind: ParseErrorKind::UnknownMimeType(value),
+            line,
+        }) => {
+            assert_eq!(value, "[ERROR]");
+            assert_eq!(line, Some(10));
+        }
+        other => panic!("unexpected result: {:?}", other),
+    }
+}
+
+// Verifies bare-CR line endings still report the correct element line number
+#[test]
+fn atom_unknown_text_type_reports_line_number_with_cr() {
+    let xml = concat!(
+        r#"<feed xmlns="http://www.w3.org/2005/Atom">"#,
+        "\r",
+        r#"<title type="[ERROR]">sample feed</title>"#,
+        "\r",
+        r#"<updated>2005-07-31T12:29:29Z</updated>"#,
+        "\r",
+        r#"<id>feed1</id>"#,
+        "\r",
+        r#"</feed>"#,
+    );
+    match parser::parse(xml.as_bytes()) {
+        Err(ParseFeedError::ParseError {
+            kind: ParseErrorKind::UnknownMimeType(mime),
+            line,
+        }) => {
+            assert_eq!(mime, "[ERROR]");
+            assert_eq!(line, Some(2));
+        }
+        other => panic!("unexpected result: {:?}", other),
     }
 }

--- a/feed-rs/src/xml/mod.rs
+++ b/feed-rs/src/xml/mod.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::cell::RefCell;
 use std::error::Error;
 use std::fmt::Debug;
-use std::io::BufRead;
+use std::io::{self, BufRead, BufReader, Read};
 use std::mem;
 
 use quick_xml::events::{BytesCData, BytesEnd, BytesStart, BytesText, Event};
@@ -15,6 +15,68 @@ mod tests;
 
 /// Iteration over the XML elements may return an error (malformed content etc)
 pub(crate) type XmlResult<T> = Result<T, XmlError>;
+
+///Line Tracking Reader
+pub(crate) struct LineTrackingReader<R> {
+    inner: R,
+    byte_len: u64,
+    line_starts: Vec<u64>,
+    last_was_cr: bool,
+}
+
+impl<R> LineTrackingReader<R> {
+    fn new(inner: R) -> Self {
+        Self {
+            inner,
+            byte_len: 0,
+            line_starts: vec![0],
+            last_was_cr: false,
+        }
+    }
+
+    fn line_for_offset(&self, offset: u64) -> usize {
+        match self.line_starts.binary_search(&offset) {
+            Ok(index) => index + 1,
+            Err(index) => index,
+        }
+    }
+
+    fn record_bytes(&mut self, bytes: &[u8]) {
+    let mut i = 0;
+    while i < bytes.len() {
+        let byte = bytes[i];
+        if self.last_was_cr {
+            if byte == b'\n' {
+                // Complete a CRLF pair: line already counted at CR
+                self.last_was_cr = false;
+                i += 1;
+                continue;
+            }
+            self.last_was_cr = false;
+        }
+        match byte {
+            b'\r' => {
+                self.line_starts.push(self.byte_len + i as u64 + 1);
+                self.last_was_cr = true;
+            }
+            b'\n' => {
+                self.line_starts.push(self.byte_len + i as u64 + 1);
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    self.byte_len += bytes.len() as u64;
+}
+}
+
+impl<R: Read> Read for LineTrackingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let read = self.inner.read(buf)?;
+        self.record_bytes(&buf[..read]);
+        Ok(read)
+    }
+}
 
 /// Produces elements from the provided source
 pub(crate) struct ElementSource<R: BufRead> {
@@ -31,7 +93,8 @@ impl<R: BufRead> ElementSource<R> {
     /// * `xml_base_uri` - the base URI if known (e.g. Content-Location, feed URI etc)
     pub(crate) fn new(xml_data: R, xml_base_uri: Option<&str>) -> XmlResult<ElementSource<R>> {
         // Create the XML parser
-        let mut reader = NsReader::from_reader(xml_data);
+        let tracking = LineTrackingReader::new(xml_data);
+        let mut reader = NsReader::from_reader(BufReader::new(tracking));
         let config = reader.config_mut();
         config.expand_empty_elements = true;
         config.trim_markup_names_in_closing_tags = true;
@@ -113,7 +176,12 @@ impl<R: BufRead> ElementSource<R> {
         while let Some(node) = state.next()? {
             match node {
                 // The start of an element may be interesting to the iterator
-                XmlEvent::Start { name, attributes, namespace } => {
+                XmlEvent::Start {
+                    name,
+                    attributes,
+                    namespace,
+                    line,
+                } => {
                     // Starting an element increases our depth
                     state.current_depth += 1;
 
@@ -127,6 +195,7 @@ impl<R: BufRead> ElementSource<R> {
                             name,
                             attributes,
                             xml_base: ElementSource::xml_base_fetch(&state),
+                            line,
                             source: self,
                             depth: state.current_depth,
                         };
@@ -227,7 +296,7 @@ impl<R: BufRead> ElementSource<R> {
 
 // Wraps the XML source and current depth of iteration
 struct SourceState<R: BufRead> {
-    reader: NsReader<R>,
+    reader: NsReader<BufReader<LineTrackingReader<R>>>,
     buf_event: Vec<u8>,
     next: XmlResult<Option<XmlEvent>>,
     current_depth: u32,
@@ -237,14 +306,13 @@ struct SourceState<R: BufRead> {
 
 impl<R: BufRead> SourceState<R> {
     // Wrap the reader in additional state (buffers, tree depth etc)
-    fn new(reader: NsReader<R>, xml_base_uri: Option<&str>) -> XmlResult<SourceState<R>> {
+    fn new(reader: NsReader<BufReader<LineTrackingReader<R>>>, xml_base_uri: Option<&str>) -> XmlResult<SourceState<R>> {
         // If we have a base URI, parse it and init at the root
         let mut base_uris = Vec::new();
         if let Some(xml_base_uri) = xml_base_uri {
             let uri = Url::parse(xml_base_uri)?;
             base_uris.push((0, uri));
         }
-
         let buf_event = Vec::with_capacity(512);
         let mut state = SourceState {
             reader,
@@ -258,18 +326,19 @@ impl<R: BufRead> SourceState<R> {
         Ok(state)
     }
 
+    fn line_for_offset(&self, offset: u64) -> usize {
+        self.reader.get_ref().get_ref().line_for_offset(offset)
+    }
+
     // Returns the next event
     fn fetch_next(&mut self) -> XmlResult<Option<XmlEvent>> {
         let decoder = self.reader.decoder();
-        let reader = &mut self.reader;
-
         loop {
-            let (ns_resolution, event) = reader.read_resolved_event_into(&mut self.buf_event)?;
-
+            let event_start = self.reader.buffer_position();
+            let line = self.line_for_offset(event_start);
+            let (ns_resolution, event) = self.reader.read_resolved_event_into(&mut self.buf_event)?;
             match event {
-                // Start of an element
                 Event::Start(ref e) => {
-                    // Parse the namespace
                     let namespace = match ns_resolution {
                         ResolveResult::Bound(ns) => decoder
                             .decode(ns.as_ref())
@@ -278,37 +347,26 @@ impl<R: BufRead> SourceState<R> {
                         ResolveResult::Unknown(_) => self.default_namespace,
                         ResolveResult::Unbound => self.default_namespace,
                     };
-
-                    return Ok(Some(XmlEvent::start(namespace, e, reader)));
+                    return Ok(Some(XmlEvent::start(namespace, e, &self.reader, line)));
                 }
-
-                // End of an element
                 Event::End(ref e) => {
-                    return Ok(Some(XmlEvent::end(e, reader)));
+                    return Ok(Some(XmlEvent::end(e, &self.reader)));
                 }
-
-                // Text
                 Event::Text(ref t) => {
-                    let event = XmlEvent::text(t, reader);
-                    if let Ok(Some(ref _t)) = event {
+                    let event = XmlEvent::text(t, &self.reader);
+                    if let Ok(Some(_)) = event {
                         return event;
                     }
                 }
-
-                // CData is converted to text
                 Event::CData(t) => {
-                    let event = XmlEvent::text_from_cdata(&t, reader);
-                    if let Ok(Some(ref _t)) = event {
+                    let event = XmlEvent::text_from_cdata(&t, &self.reader);
+                    if let Ok(Some(_)) = event {
                         return event;
                     }
                 }
-
-                // The end of the document
                 Event::Eof => {
                     return Ok(None);
                 }
-
-                // Ignore everything else
                 _ => {}
             }
         }
@@ -342,6 +400,9 @@ pub(crate) struct Element<'a, R: BufRead> {
     /// The base URL for this element per the xml:base specification (https://www.w3.org/TR/xmlbase/)
     pub xml_base: Option<Url>,
 
+    /// The line number of the start of the element.
+    line: usize,
+
     // Depth of this element
     depth: u32,
 
@@ -368,6 +429,11 @@ impl<'a, R: BufRead> Element<'a, R> {
             source: self.source,
             depth: self.depth + 1,
         }
+    }
+
+    /// Returns the line number where the tag starts.
+    pub(crate) fn line_number(&self) -> usize {
+        self.line
     }
 
     /// Concatenates the children of this node into a string
@@ -500,9 +566,16 @@ impl From<quick_xml::escape::EscapeError> for XmlError {
 // Abstraction over the underlying XML reader event model
 enum XmlEvent {
     // An XML start tag
-    Start { namespace: NS, name: String, attributes: Vec<NameValue> },
+    Start {
+        namespace: NS,
+        name: String,
+        attributes: Vec<NameValue>,
+        line: usize,
+    },
     // An XML end tag
-    End { name: String },
+    End {
+        name: String,
+    },
     // Text or CData
     Text(String),
 }
@@ -527,7 +600,7 @@ impl XmlEvent {
     }
 
     // Creates a new event corresponding to an XML start-tag
-    fn start<R: BufRead>(namespace: NS, event: &BytesStart, reader: &Reader<R>) -> XmlEvent {
+    fn start<R: BufRead>(namespace: NS, event: &BytesStart, reader: &Reader<R>, line: usize) -> XmlEvent {
         // Parse the name
         let name = XmlEvent::parse_name(event.name().as_ref(), reader);
 
@@ -557,7 +630,12 @@ impl XmlEvent {
             })
             .collect::<Vec<NameValue>>();
 
-        XmlEvent::Start { namespace, name, attributes }
+        XmlEvent::Start {
+            namespace,
+            name,
+            attributes,
+            line,
+        }
     }
 
     // Creates a new event corresponding to an XML text node

--- a/feed-rs/src/xml/tests.rs
+++ b/feed-rs/src/xml/tests.rs
@@ -257,3 +257,82 @@ fn test_iso8859_decode() -> TestResult {
 
     Ok(())
 }
+
+#[test]
+fn test_element_line_numbers_lf() -> TestResult {
+    let xml = concat!("<root>\n", "  <child>\n", "    <grandchild />\n", "  </child>\n", "  <sibling />\n", "</root>",);
+
+    let source = ElementSource::new(xml.as_bytes(), None)?;
+    let root = source.root()?.unwrap();
+    assert_eq!(root.line_number(), 1);
+
+    let mut root_children = root.children();
+    let child = root_children.next().unwrap()?;
+    assert_eq!(child.name, "child");
+    assert_eq!(child.line_number(), 2);
+
+    let mut child_children = child.children();
+    let grandchild = child_children.next().unwrap()?;
+    assert_eq!(grandchild.name, "grandchild");
+    assert_eq!(grandchild.line_number(), 3);
+    assert!(child_children.next().is_none());
+
+    let sibling = root_children.next().unwrap()?;
+    assert_eq!(sibling.name, "sibling");
+    assert_eq!(sibling.line_number(), 5);
+    assert!(root_children.next().is_none());
+
+    Ok(())
+}
+
+#[test]
+fn test_element_line_numbers_crlf() -> TestResult {
+    let xml = concat!(
+        "<root>\r\n",
+        "  <child>\r\n",
+        "    <grandchild />\r\n",
+        "  </child>\r\n",
+        "  <sibling />\r\n",
+        "</root>",
+    );
+
+    let source = ElementSource::new(xml.as_bytes(), None)?;
+    let root = source.root()?.unwrap();
+    assert_eq!(root.line_number(), 1);
+
+    let mut root_children = root.children();
+    let child = root_children.next().unwrap()?;
+    assert_eq!(child.name, "child");
+    assert_eq!(child.line_number(), 2);
+
+    let mut child_children = child.children();
+    let grandchild = child_children.next().unwrap()?;
+    assert_eq!(grandchild.name, "grandchild");
+    assert_eq!(grandchild.line_number(), 3);
+    assert!(child_children.next().is_none());
+
+    let sibling = root_children.next().unwrap()?;
+    assert_eq!(sibling.name, "sibling");
+    assert_eq!(sibling.line_number(), 5);
+    assert!(root_children.next().is_none());
+
+    Ok(())
+}
+
+#[test]
+fn test_element_line_numbers_with_prelude() -> TestResult {
+    let xml = concat!("<?xml version=\"1.0\"?>\n", "<!-- comment -->\n", "\n", "<root>\n", "  <child />\n", "</root>",);
+
+    let source = ElementSource::new(xml.as_bytes(), None)?;
+    let root = source.root()?.unwrap();
+    assert_eq!(root.name, "root");
+    assert_eq!(root.line_number(), 4);
+
+    let mut children = root.children();
+    let child = children.next().unwrap()?;
+    assert_eq!(child.name, "child");
+    assert_eq!(child.line_number(), 5);
+    assert!(children.next().is_none());
+
+    Ok(())
+}


### PR DESCRIPTION
Improved parser diagnostics for semantic feed parsing errors as mentioned in the [comment](https://github.com/feed-rs/feed-rs/blob/0e5380efbae72ad376a5b3284e7a9fa0d4f89270/feed-rs/src/parser/mod.rs#L30). 

Line numbers are captured from XML start tags and propagated through the parser so errors now report the containing element's source line when available. Errors without element context, such as `NoFeedRoot` before any XML element is identified;  do not provide any line information.

The XML layer now records the start line for emitted elements and parser call sites that construct `ParseFeedError::ParseError` use that line for:
- unsupported MIME types
- missing content
- invalid podcast role/group values
- unrecognized XML roots

Also added tests for these.